### PR TITLE
Update psycopg2 requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-psycopg2==2.6.2
+psycopg2==2.7.1
 django-councilmatic==0.9.2
 raven==5.30.0
 gunicorn==19.6.0


### PR DESCRIPTION
I had to update psycopg2 to 2.7.1 to install, was getting "Error: could not determine PostgreSQL version from '10.3'"