### PR TITLE
Always return queryset (iterable) from current_meeting

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -294,6 +294,9 @@ class LAMetroEvent(Event, LiveMediaMixin):
         if found_events:
             return calculate_current_meetings(found_events, five_minutes_from_now)
 
+        else:
+            return cls.objects.none()
+
 
     @classmethod
     def upcoming_committee_meetings(cls):


### PR DESCRIPTION
The index view code fails if there is not a current meeting:

```
Traceback (most recent call last):
  File "/home/datamade/.virtualenvs/lametro-staging/lib/python3.4/site-packages/django/core/handlers/base.py", line 149, in get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/datamade/.virtualenvs/lametro-staging/lib/python3.4/site-packages/django/core/handlers/base.py", line 147, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/datamade/.virtualenvs/lametro-staging/lib/python3.4/site-packages/django/views/decorators/cache.py", line 57, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/home/datamade/.virtualenvs/lametro-staging/lib/python3.4/site-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/datamade/.virtualenvs/lametro-staging/lib/python3.4/site-packages/django/views/generic/base.py", line 88, in dispatch
    return handler(request, *args, **kwargs)
  File "/home/datamade/.virtualenvs/lametro-staging/lib/python3.4/site-packages/django/views/generic/base.py", line 157, in get
    context = self.get_context_data(**kwargs)
  File "/home/datamade/.virtualenvs/lametro-staging/lib/python3.4/site-packages/councilmatic_core/views.py", line 159, in get_context_data
    context.update(self.extra_context())
  File "/home/datamade/lametro-staging/lametro/views.py", line 53, in extra_context
    extra['bilingual'] = bool(e for e in extra['current_meeting'] if e.bilingual)
TypeError: 'NoneType' object is not iterable
```

Return an empty queryset, rather than None, if there is no current meeting.