### PR TITLE
Run the tests from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ cache: pip
 install:
 - pip install --upgrade pip
 - pip install --upgrade -r requirements.txt
-sudo: required 
-dist: trusty 
+sudo: required
+dist: trusty
 group: deprecated-2017Q4
 addons:
   postgresql: '9.4'
 before_script:
 - mv configs/test_settings_deployment.py councilmatic/settings_deployment.py
-script: python manage.py migrate
+script: python manage.py migrate && pytest
 deploy:
   - provider: codedeploy
     access_key_id: AKIAJNYGDLOJKHOUWCAA

--- a/lametro/utils.py
+++ b/lametro/utils.py
@@ -43,33 +43,50 @@ def parse_subject(text):
         return text
 
 
-def calculate_current_meetings(found_events, five_minutes_from_now):
-    # Metro provided a spreadsheet of average meeting times. The minimum average time a meeting lasts is 52 minutes: let's round down to 50 and add the 5-minute buffer, i.e., an event will appear, regardless of Legistar, for 55 minutes past its start time. 
-    time_ago = five_minutes_from_now - timedelta(minutes=50)
-    # Custom order: show the board meeting first, when there is one.
-    # '.annotate' adds a field called 'val', which contains a boolean – we order in reverse, since false comes before true.
-    found_events = found_events.annotate(val=RawSQL("name like %s", ('%Board Meeting%',))).order_by('-val')
-    earliest_start = found_events.earliest('start_time').start_time 
-    latest_start = found_events.latest('start_time').start_time 
+def calculate_current_meetings(found_events, now=datetime.now(app_timezone)):
+    '''
+    Accept a queryset of events that started in the last six hours, or start
+    in the next five minutes, and determine which is in progress, by checking
+    Legistar for an "In Progress" indicator.
 
-    if found_events.filter(start_time__gte=time_ago):
-        # Check if previous event is still going on in Legistar.
-        previous_meeting = found_events.filter(start_time__gte=time_ago).last().get_previous_by_start_time()
+    If there are meetings scheduled concurrently, and one is a board meeting,
+    show the board meeting first.
+
+    Based on a spreadsheet of average meeting times from Metro, we assume
+    meetings last at least 55 minutes. If any found events started less than
+    55 minutes ago, display them as current if the previous meeting has
+    ended. Otherwise, check Legistar for the "In Progress" indicator.
+
+    n.b., If all found events are scheduled to start at the same time, in
+    reality they occcur one after the other.
+
+    This method should always return a queryset.
+    '''
+    fifty_five_minutes_ago = now - timedelta(minutes=55)
+
+    # '.annotate' adds a field called 'val', which contains a boolean – we order
+    # in reverse, since False comes before True, to show board meetings first.
+    found_events = found_events.annotate(val=RawSQL("name like %s", ('%Board Meeting%',)))\
+                               .order_by('-val')
+
+    if found_events.filter(start_time__gte=fifty_five_minutes_ago):
+        previous_meeting = found_events.filter(start_time__gte=fifty_five_minutes_ago)\
+                                       .last()\
+                                       .get_previous_by_start_time()
+
         if legistar_meeting_progress(previous_meeting):
             return LAMetroEvent.objects.filter(ocd_id=previous_meeting.ocd_id)
 
-        return found_events.filter(start_time__gte=time_ago)  
-    elif earliest_start == latest_start:  
-        # The IF statement handles the below cases:
-        # (1) found_events includes just one event object. Example: the first committee meeting of the day - 9:00 am on 01/18/2018
-        # (2) found_events includes multiple events that all happen at the same time (though in reality, they occur one-after-the-other). Example: the events at 9:00 am on 11/30/2017
+        return found_events.filter(start_time__gte=fifty_five_minutes_ago)
+
+    elif found_events.count() == 1:
+        event, = found_events
+        if legistar_meeting_progress(event):
+            return found_events  # Return queryset
+
+    else:
         for event in found_events:
             if legistar_meeting_progress(event):
-                return found_events
-    else: 
-        for event in found_events:
-            if legistar_meeting_progress(event):
-                # The template expects a queryset
                 return LAMetroEvent.objects.filter(ocd_id=event.ocd_id)
 
     return LAMetroEvent.objects.none()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -33,7 +33,7 @@ def test_agenda_pdf_form_submit():
         agenda_file = agenda.read()
 
         agenda_pdf_form = AgendaPdfForm(files={'agenda': SimpleUploadedFile('test_agenda.pdf', agenda_file, content_type='application/pdf')})
-    
+
         assert agenda_pdf_form.is_valid() == True
 
 
@@ -67,7 +67,7 @@ def test_updates_made_true(event, event_document):
 
 def test_updates_made_false(event, event_document):
     '''
-    This test examines the relation between an event and its EventDocument. 
+    This test examines the relation between an event and its EventDocument.
     The test updates the Agenda. Thus, the Event is not updated after the Agenda: the template tag should return False.
     '''
     event = event.build()
@@ -77,50 +77,71 @@ def test_updates_made_false(event, event_document):
     agenda.updated_at = datetime.now()
     agenda.save()
 
-    assert updates_made(event.ocd_id) == False    
+    assert updates_made(event.ocd_id) == False
 
 
-@pytest.mark.parametrize('now,progress_value,num_found,num_current,name', [
+@pytest.mark.parametrize('now,progress_value,num_found,num_current,first_event_name', [
     (datetime(2018,1,18,8,55), False, 1, 1, 'System Safety, Security and Operations Committee'),
     (datetime(2018,1,18,9,54), False, 1, 1, 'System Safety, Security and Operations Committee'),
     (datetime(2018,1,18,10,1), True, 1, 1, 'System Safety, Security and Operations Committee'),
     (datetime(2018,1,18,10,1), False, 1, 0, 'System Safety, Security and Operations Committee'),
-    (datetime(2018,1,18,10,10), False, 2, 1, 'Construction Committee'),
     (datetime(2018,1,18,10,10), True, 2, 1, 'System Safety, Security and Operations Committee'),
+    (datetime(2018,1,18,10,10), False, 2, 1, 'Construction Committee'),
     (datetime(2018,1,18,11,9), False, 2, 1, 'Construction Committee'),
     (datetime(2017,11,30,8,55), False, 2, 2, 'Regular Board Meeting'),
     (datetime(2017,11,30,9,54), False, 2, 2, 'Regular Board Meeting'),
 ])
-def test_current_committee_meeting_first(event, 
-                                         mocker, 
+def test_current_committee_meeting_first(event,
+                                         mocker,
                                          now,
                                          progress_value,
                                          num_found,
                                          num_current,
-                                         name):
+                                         first_event_name):
     '''
-    This test insures that the `calculate_current_meetings` function returns the first committee event, in a succession of events.
-    This test considers four cases to determine if the 'System Safety, Security and Operations Committee' should appear as current:
-    (1) Set the time to 8:55 am (i.e., five minutes before a 9:00 event, when the event should first appear).
-    (2) Set the time to 9:54 am: the event should continue, regardless of Legistar.
-    (3) Set the time to 10:01 am: the event should continue, because Legistar lists it as "In progress."
-    (4) Set the time to 10:01 am: the event should NOT continue, because Legistar does not list it as "In progress."
-    
-    This test considers five cases to determine if the 'Construction Committee' meeting should appear as current:
-    (1) Set the time to 10:10 am (i.e., five minutes before a 10:15 event, when the event should first appear). Assume that the previous event ('System Safety') has ended.
-    (2) Set the time to 10:10 am (i.e., five minutes before a 10:15 event, when the event should first appear) - however, assume that the previous event ('System Safety') has NOT ended.
-    (3) Set the time to 11:09 am: the meeting should continue, regardless of Legistar.
-    (4) Set the time to 11:10 am: the meeting should continue, because Legistar lists it as "In progress."
-    (5) Set the time to 11:10 am: the meeting should NOT continue, because Legistar does not list it as "In progress."
+    This test ensures that the `calculate_current_meetings` function returns the
+    first committee event, in a succession of events.
 
-    This consider cases to determine if a Board Meeting and Crenshaw Project meeting should appear as concurrent, with the Board Meeting first in the queryset:
-    (1) Set the time to 8:55 am (i.e., five minutes before a 9:00 event, when the event should first appear).
-    (2) Set the time to 9:54 am: the events should continue regardless of Legistar.
+    This test considers four cases to determine if the 'System Safety, Security
+    and Operations Committee' should appear as current:
+
+    (1) Set the time to 8:55 am (i.e., five minutes before a 9:00 event, when
+    the event should first appear).
+    (2) Set the time to 9:54 am: the event should continue, regardless of
+    Legistar.
+    (3) Set the time to 10:01 am: the event should continue, because Legistar
+    lists it as "In progress."
+    (4) Set the time to 10:01 am: the event should NOT continue, because
+    Legistar does not list it as "In progress."
+
+    This test considers five cases to determine if the 'Construction Committee'
+    meeting should appear as current:
+
+    (1) Set the time to 10:10 am (i.e., five minutes before a 10:15 event, when
+    the event should first appear). Assume that the previous event ('System
+    Safety') has ended.
+    (2) Set the time to 10:10 am (i.e., five minutes before a 10:15 event, when
+    the event should first appear) - however, assume that the previous event
+    ('System Safety') has NOT ended.
+    (3) Set the time to 11:09 am: the meeting should continue, regardless of
+    Legistar.
+    (4) Set the time to 11:10 am: the meeting should continue, because Legistar
+    lists it as "In progress."
+    (5) Set the time to 11:10 am: the meeting should NOT continue, because
+    Legistar does not list it as "In progress."
+
+    This consider cases to determine if a Board Meeting and Crenshaw Project
+    meeting should appear as concurrent, with the Board Meeting first in the
+    queryset:
+
+    (1) Set the time to 8:55 am (i.e., five minutes before a 9:00 event, when
+    the event should first appear).
+    (2) Set the time to 9:54 am: the events should continue regardless of
+    Legistar.
     '''
-
     planning_meeting_info = {
         'ocd_id': 'ocd-event/4cb9995c-c42f-4eb9-a8b4-f8e135045661',
-        'name': 'Planning and Programming Committee', 
+        'name': 'Planning and Programming Committee',
         'start_time': '2018-01-17 2:00:00',
         'slug': 'planning-and-programming-committee-f8e135045661'
     }
@@ -128,22 +149,22 @@ def test_current_committee_meeting_first(event,
 
     safety_meeting_info = {
         'ocd_id': 'ocd-event/5e84e91d-279c-4c83-a463-4a0e05784b62',
-        'name': 'System Safety, Security and Operations Committee', 
+        'name': 'System Safety, Security and Operations Committee',
         'start_time': '2018-01-18 9:00:00',
     }
     event.build(**safety_meeting_info)
 
     construction_meeting_info = {
         'ocd_id': 'ocd-event/0e793ec8-5091-4099-a115-0560d127d6f9',
-        'name': 'Construction Committee', 
+        'name': 'Construction Committee',
         'start_time': '2018-01-18 10:15:00',
         'slug': 'construction-committee-0560d127d6f9'
     }
     event.build(**construction_meeting_info)
-    
+
     ad_hoc_meeting_info = {
         'ocd_id': 'ocd-event/b9b16626-55ef-41fd-bbdb-bf5f259d416b',
-        'name': 'Ad-Hoc Customer Experience Committee', 
+        'name': 'Ad-Hoc Customer Experience Committee',
         'start_time': '2017-11-16 1:00:00',
         'slug': 'ad-hoc-customer-experience-committee-bf5f259d416b'
     }
@@ -151,7 +172,7 @@ def test_current_committee_meeting_first(event,
 
     board_meeting_info = {
         'ocd_id': 'ocd-event/ef33b22d-b166-458f-b254-b81f656ffc09',
-        'name': 'Regular Board Meeting', 
+        'name': 'Regular Board Meeting',
         'start_time': '2017-11-30 9:00:00',
         'slug': 'regular-board-meeting-b81f656ffc09'
     }
@@ -159,7 +180,7 @@ def test_current_committee_meeting_first(event,
 
     crenshaw_meeting_info = {
         'ocd_id': 'ocd-event/3c93e81f-f1a9-42ce-97fe-30c77a4a6740',
-        'name': 'Crenshaw Project Corporation', 
+        'name': 'Crenshaw Project Corporation',
         'start_time': '2017-11-30 9:00:00',
         'slug': 'crenshaw-project-corporation-30c77a4a6740'
     }
@@ -167,19 +188,20 @@ def test_current_committee_meeting_first(event,
 
     five_minutes_from_now = now + timedelta(minutes=5)
     six_hours_ago = now - timedelta(hours=6)
-    found_events = LAMetroEvent.objects.filter(start_time__lte=five_minutes_from_now)\
-              .filter(start_time__gte=six_hours_ago)\
-              .exclude(status='cancelled')\
-              .order_by('start_time')
+    found_events = LAMetroEvent.objects.filter(start_time__gte=six_hours_ago, start_time__lte=five_minutes_from_now)\
+                                       .exclude(status='cancelled')\
+                                       .order_by('start_time')
 
     assert len(found_events) == num_found
 
-    # Mock this helper function to return true or false, when checking for progress of the previous meeting (which otherwise requires hitting Legistar).
+    # Mock this helper function to return True or False, when checking progress
+    # of the previous meeting (which otherwise requires hitting Legistar).
     mocker.patch('lametro.utils.legistar_meeting_progress',
                  return_value=progress_value)
 
-    current_meeting = calculate_current_meetings(found_events, five_minutes_from_now)
+    current_meeting = calculate_current_meetings(found_events, now=now)
 
     assert len(current_meeting) == num_current
+
     if current_meeting.first():
-        assert current_meeting.first().name == name
+        assert current_meeting.first().name == first_event_name

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -85,8 +85,8 @@ def test_updates_made_false(event, event_document):
     (datetime(2018,1,18,9,54), False, 1, 1, 'System Safety, Security and Operations Committee'),
     (datetime(2018,1,18,10,1), True, 1, 1, 'System Safety, Security and Operations Committee'),
     (datetime(2018,1,18,10,1), False, 1, 0, 'System Safety, Security and Operations Committee'),
-    (datetime(2018,1,18,10,10), True, 2, 1, 'System Safety, Security and Operations Committee'),
     (datetime(2018,1,18,10,10), False, 2, 1, 'Construction Committee'),
+    (datetime(2018,1,18,10,10), True, 2, 1, 'System Safety, Security and Operations Committee'),
     (datetime(2018,1,18,11,9), False, 2, 1, 'Construction Committee'),
     (datetime(2017,11,30,8,55), False, 2, 2, 'Regular Board Meeting'),
     (datetime(2017,11,30,9,54), False, 2, 2, 'Regular Board Meeting'),
@@ -114,7 +114,7 @@ def test_current_committee_meeting_first(event,
     (4) Set the time to 10:01 am: the event should NOT continue, because
     Legistar does not list it as "In progress."
 
-    This test considers five cases to determine if the 'Construction Committee'
+    This test considers three cases to determine if the 'Construction Committee'
     meeting should appear as current:
 
     (1) Set the time to 10:10 am (i.e., five minutes before a 10:15 event, when
@@ -125,10 +125,6 @@ def test_current_committee_meeting_first(event,
     ('System Safety') has NOT ended.
     (3) Set the time to 11:09 am: the meeting should continue, regardless of
     Legistar.
-    (4) Set the time to 11:10 am: the meeting should continue, because Legistar
-    lists it as "In progress."
-    (5) Set the time to 11:10 am: the meeting should NOT continue, because
-    Legistar does not list it as "In progress."
 
     This consider cases to determine if a Board Meeting and Crenshaw Project
     meeting should appear as concurrent, with the Board Meeting first in the


### PR DESCRIPTION
This PR:

- Repairs the tests by [fixing a bug](https://github.com/datamade/la-metro-councilmatic/pull/300/files#diff-1214be6822cebe9a6279d8f370c70d30R62) in `calculate_current_events` that [only considered meetings for 45 minutes](https://github.com/datamade/la-metro-councilmatic/compare/fix_tests?expand=1#diff-1214be6822cebe9a6279d8f370c70d30L48), rather than 55 minutes, past their start time.
  - I've also [made "now" an optional kwarg](https://github.com/datamade/la-metro-councilmatic/pull/300/files#diff-1214be6822cebe9a6279d8f370c70d30R46) so we can [test the logic](https://github.com/datamade/la-metro-councilmatic/pull/300/files#diff-7491ccb4a5e2c1045607c6b5b5811018R198) with an arbitrary datetime.
- Runs the tests in `travis.yml`.
- Revises docstrings for `current_meeting`, `calculate_current_meeting`, and `test_current_committee_meeting_first`.