### PR TITLE
Displaying Related Board Reports by date

### DIFF
--- a/lametro/views.py
+++ b/lametro/views.py
@@ -83,7 +83,7 @@ class LABillDetail(BillDetailView):
         # Create list of related board reports, ordered by descending last_action_date.
         if context['legislation'].related_bills.all():
             all_related_bills = context['legislation'].related_bills.all().values('related_bill_identifier')
-            related_bills = [ bill for bill in LAMetroBill.objects.filter(identifier__in=all_related_bills) ]
+            related_bills = LAMetroBill.objects.filter(identifier__in=all_related_bills)
             context['related_bills'] = sorted(related_bills, key=lambda bill: bill.last_action_date, reverse=True)
 
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -4,7 +4,7 @@ from operator import attrgetter
 import itertools
 import urllib
 import json
-from datetime import date, timedelta, datetime
+from datetime import date, timedelta, datetime, MINYEAR
 from dateutil.relativedelta import relativedelta
 from dateutil import parser
 import requests

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -81,10 +81,12 @@ class LABillDetail(BillDetailView):
             context['packet_url'] = None
 
         # Create list of related board reports, ordered by descending last_action_date.
+        # Thanks https://stackoverflow.com/a/2179053 for how to handle null last_action_date
         if context['legislation'].related_bills.all():
             all_related_bills = context['legislation'].related_bills.all().values('related_bill_identifier')
             related_bills = LAMetroBill.objects.filter(identifier__in=all_related_bills)
-            context['related_bills'] = sorted(related_bills, key=lambda bill: bill.last_action_date, reverse=True)
+            minimum_date = datetime.date(datetime.MINYEAR, 1, 1)
+            context['related_bills'] = sorted(related_bills, key=lambda bill: bill.last_action_date or minimum_date, reverse=True)
 
 
         return context

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -85,7 +85,7 @@ class LABillDetail(BillDetailView):
         if context['legislation'].related_bills.all():
             all_related_bills = context['legislation'].related_bills.all().values('related_bill_identifier')
             related_bills = LAMetroBill.objects.filter(identifier__in=all_related_bills)
-            minimum_date = datetime.date(datetime.MINYEAR, 1, 1)
+            minimum_date = datetime(MINYEAR, 1, 1, 0, 0, 0, 0, app_timezone)
             context['related_bills'] = sorted(related_bills, key=lambda bill: bill.last_action_date or minimum_date, reverse=True)
 
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -82,7 +82,8 @@ class LABillDetail(BillDetailView):
 
         # Create list of related board reports, ordered by descending last_action_date.
         if context['legislation'].related_bills.all():
-            related_bills = [LAMetroBill.objects.get(identifier=bill.related_bill_identifier) for bill in context['legislation'].related_bills.all()]
+            all_related_bills = context['legislation'].related_bills.all().values('related_bill_identifier')
+            related_bills = [ bill for bill in LAMetroBill.objects.filter(identifier__in=all_related_bills) ]
             context['related_bills'] = sorted(related_bills, key=lambda bill: bill.last_action_date, reverse=True)
 
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -85,7 +85,7 @@ class LABillDetail(BillDetailView):
         if context['legislation'].related_bills.all():
             all_related_bills = context['legislation'].related_bills.all().values('related_bill_identifier')
             related_bills = LAMetroBill.objects.filter(identifier__in=all_related_bills)
-            minimum_date = datetime(MINYEAR, 1, 1, 0, 0, 0, 0, app_timezone)
+            minimum_date = datetime(MINYEAR, 1, 1, tzinfo=app_timezone)
             context['related_bills'] = sorted(related_bills, key=lambda bill: bill.last_action_date or minimum_date, reverse=True)
 
 


### PR DESCRIPTION
Orders the `related_bills` in `views.py` so they are displayed in descending date order.

Closes #355.