### PR TITLE
Add conditional for hiding bills with restricted views

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -85,7 +85,7 @@ class LAMetroBill(Bill):
         This issue summarizes why that might happen: https://github.com/datamade/la-metro-councilmatic/issues/345#issuecomment-421184826
         Metro staff devised three checks for knowing when to hide or show a report:
 
-        (1) Is the view restricted, i.e., is `MatterRestrictViewViaWeb` set to True in the Legistar API? We skip these bills further upstream. https://github.com/opencivicdata/scrapers-us-municipal/pull/251
+        (1) Is the view restricted, i.e., is `MatterRestrictViewViaWeb` set to True in the Legistar API? Then, do not show it.
 
         (2) Does the Bill have a classification of "Board Box"? Then, show it.
 
@@ -96,6 +96,9 @@ class LAMetroBill(Bill):
         This strategy minimizes complexity (e.g., attempting to implement an LAMetroBillManager),
         and this strategy avoids making adjustments to the `data_integrity` script (https://github.com/datamade/django-councilmatic/blob/master/councilmatic_core/management/commands/data_integrity.py)
         '''
+        if self.restrict_view == True:
+            return False
+
         if self.bill_type == "Board Box":
             return True
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = tests.test_config
+filterwarnings =
+    ignore::django.utils.deprecation.RemovedInDjango20Warning

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psycopg2==2.7.6.1
-django-councilmatic==0.10.11
+django-councilmatic==0.10.14
 django-debug-toolbar==1.9.1
 raven==5.30.0
 gunicorn==19.6.0

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -64,19 +64,22 @@ def test_format_full_text(bill, text, subject):
 
     assert format_full_text(full_text) == subject
 
-@pytest.mark.parametrize('bill_type,event_status,assertion', [
-        ('Board Box', 'passed', True),
-        ('Resolution', 'passed', True),
-        ('Resolution', 'cancelled', True),
-        ('Resolution', 'confirmed', False),
+@pytest.mark.parametrize('restrict_view,bill_type,event_status,assertion', [
+        (True,'Board Box', 'passed', False),
+        (False,'Board Box', 'passed', True),
+        (False,'Resolution', 'passed', True),
+        (False,'Resolution', 'cancelled', True),
+        (False,'Resolution', 'confirmed', False),
     ])
 def test_viewable_bill(bill, 
-                       event_agenda_item, 
+                       event_agenda_item,
+                       restrict_view, 
                        bill_type, 
                        event_status, 
                        assertion):
     bill_info = {
         'bill_type': bill_type,
+        'restrict_view': restrict_view,
     }
     bill = bill.build(**bill_info)
     bill.refresh_from_db()


### PR DESCRIPTION
This PR adds a conditional to the `is_visible` property: it explicitly hides bills marked as having a restricted view in Legistar.

It works in cooperation with https://github.com/opencivicdata/scrapers-us-municipal/pull/258, https://github.com/opencivicdata/python-legistar-scraper/pull/81, and https://github.com/datamade/django-councilmatic/pull/232

N.b., I'll get the tests passing once I can add the above-mentioned changes in Django Councilmatic to the testing requirements.