### PR TITLE
Pin to master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psycopg2==2.7.6.1
-django-councilmatic==0.10.14
+https://github.com/datamade/django-councilmatic/zipball/master
 django-debug-toolbar==1.9.1
 raven==5.30.0
 gunicorn==19.6.0


### PR DESCRIPTION
We are not actively developing the other Councilmatic instances. For now, we can safely pin Metro to django-councilmatic master (to avoid cutting unneeded pypi releases). 