### PR TITLE
Fixing overlapping text on front page

### DIFF
--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -267,6 +267,22 @@ div#toggleControls { margin-bottom: 1em; }
     .remove-order-value {
         display: none;
     }
+
+    .site-intro-search input {
+      max-height: 30px;
+      padding: 2px;
+    }
+
+    .site-intro-search .input-group-btn button {
+      max-height: 30px;
+      padding: 2px;
+    }
+    div.btn-group label.btn.btn-primary.btn-search-option.active,
+    div.btn-group label.btn.btn-primary.btn-search-option {
+      border-radius: 4px;
+      padding: 4px 8px;
+      margin-bottom: 10px;
+    }
 }
 
 @media (min-width: 767px) and (max-width: 1180px) {

--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -247,7 +247,7 @@ div#toggleControls { margin-bottom: 1em; }
     }
 
     .home-header {
-        font-size: 32px;
+        font-size: 26px;
     }
 
     .nav a.sort-by, .nav a.btn {

--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -263,7 +263,7 @@ div#toggleControls { margin-bottom: 1em; }
     }
 }
 
-@media only screen and (max-width : 400px) {
+@media only screen and (max-width : 415px) {
     .remove-order-value {
         display: none;
     }

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -5,15 +5,15 @@
     <div class="container-fluid" id="section-photo">
         <div class="row-fluid">
             <div class='col-sm-10 col-sm-offset-1'>
-                <span class="hidden-xs"><br/><br/></span>
+                <span class="hidden-xs hidden-sm"><br/><br/></span>
                     <h1 class="home-header">Los Angeles County Metropolitan Transportation Authority</h1>
-                <span class="hidden-xs"><br/></span>
+                <span class="hidden-xs hidden-sm"><br/></span>
                 <p class="h3">
                     <span class="text-bg">Search Metro Board Reports (2015 – present)</span>
                 </p>
                 <form class="search form-search=" action="/search/" method="GET">
                     <div class="input-group site-intro-search">
-                        <input name="q" type="text" class="input-lg form-control" placeholder="{{ SEARCH_PLACEHOLDER_TEXT }}">
+                        <input name="q" type="text" class="input-lg form-control form-lg" placeholder="{{ SEARCH_PLACEHOLDER_TEXT }}">
                         <div class='input-group-btn'>
                             <button type="submit" class="btn btn-lg btn-primary">
                                 <i class='fa fa-fw fa-search'></i>
@@ -39,7 +39,7 @@
     <div class="container-fluid" id="section-intro">
         <div class="row-fluid">
             <div class='col-sm-10 col-sm-offset-1'>
-               
+
                 <div class="row">
                     <div class='col-sm-7'>
                         <h2>
@@ -77,7 +77,7 @@
                         {% include "partials/index_metro_description.html" %}
                     </div>
                 </div>
-                
+
             </div>
         </div>
     </div>


### PR DESCRIPTION
Addressing #350.

- Media query added to accommodate the size of the form entry and button for xs screens
- Added `hidden-sm` on the breaks so that the text doesn't overlap on tablet sizes either