### PR TITLE
Have Related Board Reports shown in order

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -14,7 +14,6 @@ import requests
 from councilmatic_core.models import Bill, Event, Post, Person, Organization, \
     Action, EventMedia
 
-from lametro.utils import find_last_action_date
 
 app_timezone = pytz.timezone(settings.TIME_ZONE)
 
@@ -72,7 +71,29 @@ class LAMetroBill(Bill):
         return self.from_organization
 
     def get_last_action_date(self):
-        return find_last_action_date(self.ocd_id)
+        '''
+        Several Metro bills do not have "histories."
+        Discussed in this issue:
+        https://github.com/datamade/la-metro-councilmatic/issues/340
+
+        If a bill does not have a history, then determine its `last_action_date` by
+        looking for the most recent agenda that references the bill. Consider only
+        events that have already occurred, so the last action date is not in the
+        future.
+        '''
+        actions = Action.objects.filter(_bill_id=self.ocd_id)
+        last_action_date = ''
+
+        if actions:
+            last_action_date = actions.reverse()[0].date
+        else:
+            events = Event.objects.filter(agenda_items__bill_id=self.ocd_id,
+                                          start_time__lt=timezone.now())
+
+            if events:
+                last_action_date = events.latest('start_time').start_time
+
+        return last_action_date
 
     @property
     def topics(self):

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -25,7 +25,7 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
     def prepare_last_action_date(self, obj):
         # Solr seems to be fussy about the time format, and we do not need the time, just the date stamp.
         # https://lucene.apache.org/solr/guide/7_5/working-with-dates.html#date-formatting
-        last_action_date = obj.get_last_action_date(obj.ocd_id)
+        last_action_date = obj.get_last_action_date()
         if last_action_date:
             return last_action_date.date()
 

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -5,7 +5,7 @@ from councilmatic_core.haystack_indexes import BillIndex
 from councilmatic_core.models import Action, EventAgendaItem
 
 from lametro.models import LAMetroBill
-from lametro.utils import format_full_text, parse_subject, find_last_action_date
+from lametro.utils import format_full_text, parse_subject
 
 class LAMetroBillIndex(BillIndex, indexes.Indexable):
     topics = indexes.MultiValueField(faceted=True)
@@ -25,7 +25,7 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
     def prepare_last_action_date(self, obj):
         # Solr seems to be fussy about the time format, and we do not need the time, just the date stamp.
         # https://lucene.apache.org/solr/guide/7_5/working-with-dates.html#date-formatting
-        last_action_date = find_last_action_date(obj.ocd_id)
+        last_action_date = obj.get_last_action_date(obj.ocd_id)
         if last_action_date:
             return last_action_date.date()
 
@@ -38,7 +38,7 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
             if results:
                 return parse_subject(results)
         else:
-            return obj.bill_type    
+            return obj.bill_type
 
     def prepare_topics(self, obj):
         return [s.subject for s in obj.subjects.all()]

--- a/lametro/templates/partials/tags.html
+++ b/lametro/templates/partials/tags.html
@@ -1,13 +1,8 @@
 {% load extras %}
-{% if result.last_action_date %}
-    <p class="small text-muted condensed">
-        <i class="fa fa-fw fa-calendar-o"></i> {{result.last_action_date|date:'n/d/Y'}} - {{result.object.current_action.description | remove_action_subj }} (most recent action)
-    </p>
-{% elif result.object.get_last_action_date %}
-     <p class="small text-muted condensed">
-        <i class="fa fa-fw fa-calendar-o"></i> {{result.object.get_last_action_date|date:'n/d/Y'}} - {{result.object.current_action.description | remove_action_subj }} (most recent action)
-    </p>
-{% endif %}
+<p class="small text-muted condensed">
+  <i class="fa fa-fw fa-calendar-o"></i> {{result.object.get_last_action_date|date:'n/d/Y'}} - {{result.object.current_action.description | remove_action_subj }} (most recent action)
+</p>
+
 
 {% if result.object.primary_sponsor %}
     <p class="small text-muted condensed">

--- a/lametro/utils.py
+++ b/lametro/utils.py
@@ -39,28 +39,3 @@ def format_full_text(full_text):
 def parse_subject(text):
     if ('[PROJECT OR SERVICE NAME]' not in text) and ('[DESCRIPTION]' not in text) and ('[CONTRACT NUMBER]' not in text):
         return text.strip()
-
-def find_last_action_date(bill_ocd_id):
-    '''
-    Several Metro bills do not have "histories."
-    Discussed in this issue:
-    https://github.com/datamade/la-metro-councilmatic/issues/340
-
-    If a bill does not have a history, then determine its `last_action_date` by
-    looking for the most recent agenda that references the bill. Consider only
-    events that have already occurred, so the last action date is not in the
-    future.
-    '''
-    actions = Action.objects.filter(_bill_id=bill_ocd_id)
-    last_action_date = ''
-
-    if actions:
-        last_action_date = actions.reverse()[0].date
-    else:
-        events = Event.objects.filter(agenda_items__bill_id=bill_ocd_id,
-                                      start_time__lt=timezone.now())
-
-        if events:
-            last_action_date = events.latest('start_time').start_time
-
-    return last_action_date

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -86,7 +86,7 @@ class LABillDetail(BillDetailView):
             all_related_bills = context['legislation'].related_bills.all().values('related_bill_identifier')
             related_bills = LAMetroBill.objects.filter(identifier__in=all_related_bills)
             minimum_date = datetime(MINYEAR, 1, 1, tzinfo=app_timezone)
-            context['related_bills'] = sorted(related_bills, key=lambda bill: bill.last_action_date or minimum_date, reverse=True)
+            context['related_bills'] = sorted(related_bills, key=lambda bill: bill.get_last_action_date() or minimum_date, reverse=True)
 
 
         return context

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -7,13 +7,13 @@ from django.core.urlresolvers import reverse
 from django.utils import timezone
 
 from councilmatic_core.models import Bill, RelatedBill, Event, EventAgendaItem
-from lametro.utils import format_full_text, parse_subject, find_last_action_date
+from lametro.utils import format_full_text, parse_subject
 
 
 # This collection of tests checks the functionality of Bill-specific views, helper functions, and relations.
 def test_bill_url(client, bill):
     '''
-    This test checks that the bill detail view returns a successful response. 
+    This test checks that the bill detail view returns a successful response.
     '''
     bill = bill.build()
     url = reverse('bill_detail', kwargs={'slug': bill.slug})
@@ -29,21 +29,21 @@ def test_related_bill_relation(client, bill):
 
     related_bill_info = {
         'ocd_id': 'ocd-bill/8b90f9f4-1421-4450-a34e-766ca2f8be26',
-        'description': 'RECEIVE AND FILE the Draft Measure M Project Acceleration/Deceleration Factors and Evaluation Process', 
-        'ocd_created_at': '2017-06-16 14:23:30.970325-05', 
-        'ocd_updated_at': '2017-06-16 14:23:30.970325-05', 
+        'description': 'RECEIVE AND FILE the Draft Measure M Project Acceleration/Deceleration Factors and Evaluation Process',
+        'ocd_created_at': '2017-06-16 14:23:30.970325-05',
+        'ocd_updated_at': '2017-06-16 14:23:30.970325-05',
         'updated_at': '2017-07-26 11:06:47.1853',
-        'identifier': '2017-0596', 
-        'slug': '2017-0596' 
+        'identifier': '2017-0596',
+        'slug': '2017-0596'
     }
 
     related_bill = bill.build(**related_bill_info)
 
-    RelatedBill.objects.create(related_bill_identifier=related_bill.identifier, 
-                               central_bill_id=central_bill.ocd_id)   
+    RelatedBill.objects.create(related_bill_identifier=related_bill.identifier,
+                               central_bill_id=central_bill.ocd_id)
 
     assert central_bill.related_bills.count() == 1
-    assert central_bill.related_bills.first().related_bill_identifier == '2017-0596'  
+    assert central_bill.related_bills.first().related_bill_identifier == '2017-0596'
 
 @pytest.mark.parametrize('text,subject', [
     ("..Subject\nSUBJECT:\tFOOD SERVICE OPERATOR\n\n..Action\nACTION:\tAWARD SERVICES CONTRACT\n\n..", "\tFOOD SERVICE OPERATOR"),
@@ -52,7 +52,7 @@ def test_related_bill_relation(client, bill):
 ])
 def test_format_full_text(bill, text, subject):
     '''
-    This test checks that format_full_text correctly parses the subject header. 
+    This test checks that format_full_text correctly parses the subject header.
     '''
     bill_info = {
         'ocr_full_text': text
@@ -71,11 +71,11 @@ def test_format_full_text(bill, text, subject):
         (False,'Resolution', 'cancelled', True),
         (False,'Resolution', 'confirmed', False),
     ])
-def test_viewable_bill(bill, 
+def test_viewable_bill(bill,
                        event_agenda_item,
-                       restrict_view, 
-                       bill_type, 
-                       event_status, 
+                       restrict_view,
+                       bill_type,
+                       event_status,
                        assertion):
     bill_info = {
         'bill_type': bill_type,
@@ -117,7 +117,7 @@ def test_last_action_date_has_already_occurred(bill, event):
     assert Event.objects.filter(agenda_items__bill_id=some_bill.ocd_id)\
                         .count() == 2
 
-    last_action_date = find_last_action_date(some_bill)
+    last_action_date = some_bill.get_last_action_date()
 
     # Assert the last action matches the event that has already occurred.
     assert last_action_date == two_weeks_ago


### PR DESCRIPTION
This refactors `find_last_action_date()` utility function to instead be a a method on the `Bill` class. It implements [the steps outlined in this comment](https://github.com/datamade/la-metro-councilmatic/issues/355#issuecomment-466121608).

Addresses #355.