### PR TITLE
Add bill manager and subclass integrity script

### DIFF
--- a/lametro/management/commands/data_integrity.py
+++ b/lametro/management/commands/data_integrity.py
@@ -1,0 +1,28 @@
+import logging
+import logging.config
+
+from django.conf import settings
+
+from councilmatic_core.management.commands import data_integrity
+from lametro.models import LAMetroBill
+
+
+logging.config.dictConfig(settings.LOGGING)
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("pysolr").setLevel(logging.WARNING)
+logger = logging.getLogger(__name__)
+
+class Command(data_integrity.Command):
+    '''
+    Subclasses the data_integrity management command in django-councilmatic:
+    https://github.com/datamade/django-councilmatic/blob/master/councilmatic_core/management/commands/data_integrity.py
+
+    This command counts LAMetroBill objects, which undergo additional fiiltering 
+    via the LAMetroBillManager.
+    '''
+    class Meta:
+        proxy = True
+
+    def count_councilmatic_bills(self):
+
+        return LAMetroBill.objects.all().count()

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -18,7 +18,44 @@ from councilmatic_core.models import Bill, Event, Post, Person, Organization, \
 
 app_timezone = pytz.timezone(settings.TIME_ZONE)
 
+
+class LAMetroBillManager(models.Manager):
+    def get_queryset(self):
+        '''
+        The Councilmatic database contains both "private" and "public" bills. 
+        This issue thread explains why: 
+        https://github.com/datamade/la-metro-councilmatic/issues/345#issuecomment-455683240
+        
+        We do not display "private" bills in Councilmatic.
+        Metro staff devised three checks for knowing when to hide or show a report:
+
+        (1) Is the bill private (i.e., `restrict_view` is True)? Then, do not show it.
+        N.b., the scrapers contain logic for populating the restrict_view field:
+        https://github.com/opencivicdata/scrapers-us-municipal/blob/master/lametro/bills.py
+
+        (2) Does the Bill have a classification of "Board Box"? Then, show it.
+
+        (3) Is the Bill on a published agenda, i.e., an event with the 
+        status of "passed" or "cancelled"? Then, show it.
+
+        NOTE: Be sure to use LAMetroBill, rather than the base Bill class,
+        when getting bill querysets. Otherwise restricted view bills
+        may slip through the crevices of Councilmatic display logic.
+        '''
+
+        from django.db.models import Q
+
+        filtered_qs = super().get_queryset().exclude(restrict_view=True)\
+                                            .filter(Q(related_agenda_items__event__status='passed') | \
+                                                    Q(related_agenda_items__event__status='cancelled') | \
+                                                    Q(bill_type='Board Box'))\
+                                            .distinct()
+
+        return filtered_qs
+
+
 class LAMetroBill(Bill):
+    objects = LAMetroBillManager()
 
     class Meta:
         proxy = True
@@ -100,36 +137,6 @@ class LAMetroBill(Bill):
     def topics(self):
         return [s.subject for s in self.subjects.all()]
 
-    @property
-    def is_viewable(self):
-        '''
-        Sometimes, a Bill may be imported to Councilmatic, though it should not be visible to the public.
-        This issue summarizes why that might happen: https://github.com/datamade/la-metro-councilmatic/issues/345#issuecomment-421184826
-        Metro staff devised three checks for knowing when to hide or show a report:
-
-        (1) Is the view restricted, i.e., is `MatterRestrictViewViaWeb` set to True in the Legistar API? Then, do not show it.
-
-        (2) Does the Bill have a classification of "Board Box"? Then, show it.
-
-        (3) Is the Bill on a published agenda, i.e., an event with the status of "passed" or "cancelled"? Then, show it.
-
-        This property coms into play when filtering the SearchQuerySet object in  LAMetroCouncilmaticSearchForm (views.py).
-        Note: we filter the sqs object, rather than remove "hidden" bills from the Solr index.
-        This strategy minimizes complexity (e.g., attempting to implement an LAMetroBillManager),
-        and this strategy avoids making adjustments to the `data_integrity` script (https://github.com/datamade/django-councilmatic/blob/master/councilmatic_core/management/commands/data_integrity.py)
-        '''
-        if self.restrict_view == True:
-            return False
-
-        if self.bill_type == "Board Box":
-            return True
-
-        events_with_bill = Event.objects.filter(agenda_items__bill_id=self.ocd_id)
-        passed_events = [event for event in events_with_bill if (event.status == 'passed' or event.status == 'cancelled')]
-        if passed_events:
-            return True
-
-        return False
 
 class LAMetroPost(Post):
 

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -37,7 +37,11 @@ class LAMetroBillManager(models.Manager):
         (3) Is the Bill on a published agenda, i.e., an event with the 
         status of "passed" or "cancelled"? Then, show it.
 
-        NOTE: Be sure to use LAMetroBill, rather than the base Bill class,
+        NOTE! A single bill can appear on multiple event agendas.
+        We thus call 'distinct' on the below query, otherwise
+        the queryset would contain duplicate bills. 
+
+        WARNING! Be sure to use LAMetroBill, rather than the base Bill class,
         when getting bill querysets. Otherwise restricted view bills
         may slip through the crevices of Councilmatic display logic.
         '''

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -2,15 +2,14 @@ import pytz
 import re
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
+import requests
 
 from django.conf import settings
 from django.db import models, connection
 from django.db.models.expressions import RawSQL
 from django.utils import timezone
 from django.contrib.auth.models import User
-from django.db.models import Max, Min, Prefetch, Case, When, Value
-
-import requests
+from django.db.models import Max, Min, Prefetch, Case, When, Value, Q
 
 from councilmatic_core.models import Bill, Event, Post, Person, Organization, \
     Action, EventMedia
@@ -42,9 +41,6 @@ class LAMetroBillManager(models.Manager):
         when getting bill querysets. Otherwise restricted view bills
         may slip through the crevices of Councilmatic display logic.
         '''
-
-        from django.db.models import Q
-
         filtered_qs = super().get_queryset().exclude(restrict_view=True)\
                                             .filter(Q(related_agenda_items__event__status='passed') | \
                                                     Q(related_agenda_items__event__status='cancelled') | \

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -45,6 +45,3 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
 
     def prepare_attachment_text(self, obj):
         return ' '.join(d.full_text for d in obj.documents.all() if d.full_text)
-
-    def prepare_viewable(self, obj):
-        return obj.is_viewable

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -705,8 +705,6 @@ class LAMetroCouncilmaticSearchForm(CouncilmaticSearchForm):
             # Don't auto-escape my query! https://django-haystack.readthedocs.io/en/v2.4.1/searchqueryset_api.html#SearchQuerySet.filter
             sqs = sqs.filter_or(attachment_text=Raw(self.cleaned_data['q']))
 
-        sqs = sqs.filter(viewable=True)
-
         return sqs
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psycopg2==2.7.6.1
-https://github.com/datamade/django-councilmatic/zipball/master
+django-councilmatic==0.10.15
 django-debug-toolbar==1.9.1
 raven==5.30.0
 gunicorn==19.6.0

--- a/solr_configs/conf/schema.xml
+++ b/solr_configs/conf/schema.xml
@@ -153,7 +153,6 @@
     <field name="attachment_text" type="text_en" indexed="true" stored="false" multiValued="false" />
     <field name="source_url" type="string" indexed="false" stored="true" multiValued="false" />
     <field name="identifier" type="text_en" indexed="true" stored="true" multiValued="false" />
-    <field name="viewable" type="boolean" indexed="true" stored="false" multiValued="false" />
 
     <!-- Dynamic field definitions allow using convention over configuration
     for fields via the specification of patterns to match field names. 

--- a/solr_scripts/schema.xml
+++ b/solr_scripts/schema.xml
@@ -200,8 +200,6 @@
     <field name="source_url" type="string" indexed="false" stored="true" multiValued="false" />
 
     <field name="identifier" type="text_en" indexed="true" stored="true" multiValued="false" />
-
-    <field name="viewable" type="boolean" indexed="true" stored="false" multiValued="false" />
     
   </fields>
 

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -64,38 +64,38 @@ def test_format_full_text(bill, text, subject):
 
     assert format_full_text(full_text) == subject
 
-@pytest.mark.parametrize('restrict_view,bill_type,event_status,assertion', [
-        (True,'Board Box', 'passed', False),
-        (False,'Board Box', 'passed', True),
-        (False,'Resolution', 'passed', True),
-        (False,'Resolution', 'cancelled', True),
-        (False,'Resolution', 'confirmed', False),
-    ])
-def test_viewable_bill(bill,
-                       event_agenda_item,
-                       restrict_view,
-                       bill_type,
-                       event_status,
-                       assertion):
-    bill_info = {
-        'bill_type': bill_type,
-        'restrict_view': restrict_view,
-    }
-    bill = bill.build(**bill_info)
-    bill.refresh_from_db()
+# @pytest.mark.parametrize('restrict_view,bill_type,event_status,assertion', [
+#         (True,'Board Box', 'passed', False),
+#         (False,'Board Box', 'passed', True),
+#         (False,'Resolution', 'passed', True),
+#         (False,'Resolution', 'cancelled', True),
+#         (False,'Resolution', 'confirmed', False),
+#     ])
+# def test_viewable_bill(bill,
+#                        event_agenda_item,
+#                        restrict_view,
+#                        bill_type,
+#                        event_status,
+#                        assertion):
+#     bill_info = {
+#         'bill_type': bill_type,
+#         'restrict_view': restrict_view,
+#     }
+#     bill = bill.build(**bill_info)
+#     bill.refresh_from_db()
 
-    event_agenda_item_info = {
-        'bill_id': bill.ocd_id,
-    }
-    item = event_agenda_item.build(**event_agenda_item_info)
-    item.refresh_from_db()
+#     event_agenda_item_info = {
+#         'bill_id': bill.ocd_id,
+#     }
+#     item = event_agenda_item.build(**event_agenda_item_info)
+#     item.refresh_from_db()
 
-    event = Event.objects.get(ocd_id=item.event_id)
-    event.status = event_status
-    event.save()
-    event.refresh_from_db()
+#     event = Event.objects.get(ocd_id=item.event_id)
+#     event.status = event_status
+#     event.save()
+#     event.refresh_from_db()
 
-    assert bill.is_viewable == assertion
+#     assert bill.is_viewable == assertion
 
 @pytest.mark.django_db
 def test_last_action_date_has_already_occurred(bill, event):


### PR DESCRIPTION
This PR responds to issue #409.

I added a BillManager and removed the Bill property `is_viewable`. This property came into use in fetching results from Solr: without `is_viewable`, we no longer need the `viewable` filed in the Solr schema. 'tis removed!

The `data_integrity` script would not behave as expected with these changes. [This django-councilmatic PR](https://github.com/datamade/django-councilmatic/pull/237/files) enables a way to subclass the `data_integrity` script, so that we query for LAMetroBills, not the base class.