### PR TITLE
Filter for bills, do not get them

### DIFF
--- a/lametro/views.py
+++ b/lametro/views.py
@@ -201,10 +201,16 @@ class LAMetroEventDetail(EventDetailView):
 
                 obj = obj + (packet_url,)
 
-                # Add status
-                board_report = LAMetroBill.objects.get(ocd_id=ocd_id)
-                obj = obj + (board_report.inferred_status,)
-                cursor_copy.append(obj)
+                # The cursor object potentially includes public and private bills.
+                # However, the LAMetroBillManager excludes private bills 
+                # from the LAMetroBill queryset. 
+                # Attempting to `get` a private bill from LAMetroBill.objects
+                # raises a DoesNotExist error. As a precaution, we use filter()
+                # rather than get().
+                board_report = LAMetroBill.objects.filter(ocd_id=ocd_id)
+                if board_report:
+                    obj = obj + (board_report.first().inferred_status,)
+                    cursor_copy.append(obj)
 
             # Create a named tuple
             board_report_tuple = namedtuple('BoardReportProperties', columns, rename=True)


### PR DESCRIPTION
We recently added [a bill manager](https://github.com/datamade/la-metro-councilmatic/blob/master/lametro/models.py#L21), which filters private bills. 

The event detail view searches for related board reports by querying the database with raw SQL. This means: the query can potentially return private bills. Trying to fetch such bills (i.e., the ones returned via SQL) from LAMetroBill.objects() raises a DoesNotExist error, causing the Event page to load an InternalServerError. 

This PR provides a work around.

Handles: https://sentry.io/organizations/datamade/issues/914009560/?project=137567&referrer=webhooks_plugin&statsPeriod=14d