### PR TITLE
Use LAMetroOrganization on council members view

### DIFF
--- a/lametro/views.py
+++ b/lametro/views.py
@@ -477,7 +477,7 @@ class LABoardMembersView(CouncilMembersView):
             membership_objects = sorted(membership_objects, key=lambda x: x[5])
             context['membership_objects'] = membership_objects
 
-            board = LAMetroOrganization.objects.get(ocd_id='ocd-organization/42e23f04-de78-436a-bec5-ab240c1b977c')
+            board = LAMetroOrganization.objects.get(ocd_id=settings.OCD_CITY_COUNCIL_ID)
             context['recent_activity'] = board.actions.order_by('-date', '-_bill__identifier', '-order')
             context['recent_events'] = board.recent_events
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -477,7 +477,7 @@ class LABoardMembersView(CouncilMembersView):
             membership_objects = sorted(membership_objects, key=lambda x: x[5])
             context['membership_objects'] = membership_objects
 
-            board = Organization.objects.get(ocd_id='ocd-organization/42e23f04-de78-436a-bec5-ab240c1b977c')
+            board = LAMetroOrganization.objects.get(ocd_id='ocd-organization/42e23f04-de78-436a-bec5-ab240c1b977c')
             context['recent_activity'] = board.actions.order_by('-date', '-_bill__identifier', '-order')
             context['recent_events'] = board.recent_events
 


### PR DESCRIPTION
This PR handles issue #415. 

The `LABoardMembersView` now uses the `LAMetroOrganization` to discover `recent_events`: [the Metro `recent_events` function queries the LAMetroEvent](https://github.com/datamade/la-metro-councilmatic/blob/master/lametro/models.py#L478) and thus excludes test events.