### PR TITLE
Use version of requests with security patch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ django-debug-toolbar==1.9.1
 raven==5.30.0
 gunicorn==19.6.0
 PyPDF2==1.26.0
-requests==2.7.0
+requests==2.20.0
 pytest
 pytest-django
 pytest-mock==1.6.3


### PR DESCRIPTION
This PR handles the incessant security warning provided from Github. 

I updated our version of requests. The differences between 2.7 and 2.20 should not affect the usability of LA Metro: http://docs.python-requests.org/en/master/community/updates/