### PR TITLE
Hide link to download report and attachments if no attachments exist

### DIFF
--- a/lametro/templates/lametro/legislation.html
+++ b/lametro/templates/lametro/legislation.html
@@ -48,7 +48,7 @@
                 </p>
 
 
-                {% if packet_url %}
+                {% if packet_url and attachments%}
                     <p>
                         <a href="{{packet_url}}"><i class="fa fa-files-o" aria-hidden="true"></i> Download Board Report and Attachments</a>
                     </p>


### PR DESCRIPTION
This PR handles issue #381, specifically:

> The link to "Download Board Report and Attachments" is displayed, but no attachments are linked in sidebar and there are no attachments to the Report when it's downloaded via that link: https://boardagendas.metro.net/board-report/2017-0649/