### PR TITLE
Remove Solr dependency on events page

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Overview
+
+Brief description of what this PR does, and why it is needed.
+
+### Checklist
+
+- [ ] PR has a descriptive enough title to be useful in changelogs
+
+### Demo
+
+Optional. Screenshots, `curl` examples, etc.
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+
+## Testing Instructions
+
+ * How to test this PR
+ * Prefer bulleted description
+ * Start after checking out this branch
+ * Include any setup required, such as bundling scripts, restarting services, etc.
+ * Include test case, and expected output
+
+Handles #XXX

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -460,7 +460,7 @@ class LAMetroEvent(Event, LiveMediaMixin):
 
 
     @property
-    def event_minutes(self):
+    def board_event_minutes(self):
         '''
         This method returns the link to an Event's minutes. 
 
@@ -469,19 +469,20 @@ class LAMetroEvent(Event, LiveMediaMixin):
         For these, we can query board reports 
         for indicative text, i.e., "minutes of the regular..."
         '''
-        try:
-            doc = self.documents.get(note__icontains='RBM Minutes')
-        except EventDocument.DoesNotExist:
+        if 'regular board meeting' in self.name.lower():
             try:
-                date = self.start_time.date().strftime('%B %d, %Y')
-                content = 'minutes of the regular board meeting held ' + date
-                board_report = Bill.objects.get(ocr_full_text__icontains=content, bill_type='Minutes')
-            except Bill.DoesNotExist:
-                return None
+                doc = self.documents.get(note__icontains='RBM Minutes')
+            except EventDocument.DoesNotExist:
+                try:
+                    date = self.start_time.date().strftime('%B %d, %Y')
+                    content = 'minutes of the regular board meeting held ' + date
+                    board_report = Bill.objects.get(ocr_full_text__icontains=content, bill_type='Minutes')
+                except Bill.DoesNotExist:
+                    return None
+                else:
+                    return '/board-report/' + board_report.slug
             else:
-                return '/board-report/' + board_report.slug
-        else:
-            return doc.url
+                return doc.url
 
 
 class LAMetroEventMedia(EventMedia):

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -468,19 +468,21 @@ class LAMetroEvent(Event, LiveMediaMixin):
         LAMetroBill. For these, we can query for an EventDocument and 
         return its link. 
         '''
-        if 'regular board meeting' in self.name.lower():
-            date = self.start_time.date().strftime('%B %d, %Y')
-            content = 'minutes of the regular board meeting held ' + date
+        date = self.start_time.date().strftime('%B %d, %Y')
+        content = 'minutes of the regular board meeting held ' + date
+        try:
+            import pdb; pdb.set_trace()
+            board_report = LAMetroBill.objects.get(ocr_full_text__icontains=content, bill_type='Minutes')
+        except LAMetroBill.DoesNotExist:
             try:
-                board_report = LAMetroBill.objects.get(ocr_full_text__icontains=content, bill_type='Minutes')
-                return '/board-report/' + board_report.slug
-            except LAMetroBill.DoesNotExist:
                 doc = self.documents.get(note__icontains='RBM Minutes')
-                return doc.url
             except EventDocument.DoesNotExist:
                 return None
+            else:
+                return doc.url
         else:
-            return None
+            return '/board-report/' + board_report.slug
+
 
 class LAMetroEventMedia(EventMedia):
 

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -464,24 +464,24 @@ class LAMetroEvent(Event, LiveMediaMixin):
         '''
         This method returns the link to an Event's minutes. 
 
-        A small number of Events do not have minutes in a corresponding
-        LAMetroBill. For these, we can query for an EventDocument and 
-        return its link. 
+        A small number of Events do not have minutes in 
+        a discoverable, corresponding EventDocument. 
+        For these, we can query board reports 
+        for indicative text, i.e., "minutes of the regular..."
         '''
-        date = self.start_time.date().strftime('%B %d, %Y')
-        content = 'minutes of the regular board meeting held ' + date
         try:
-            import pdb; pdb.set_trace()
-            board_report = LAMetroBill.objects.get(ocr_full_text__icontains=content, bill_type='Minutes')
-        except LAMetroBill.DoesNotExist:
+            doc = self.documents.get(note__icontains='RBM Minutes')
+        except EventDocument.DoesNotExist:
             try:
-                doc = self.documents.get(note__icontains='RBM Minutes')
-            except EventDocument.DoesNotExist:
+                date = self.start_time.date().strftime('%B %d, %Y')
+                content = 'minutes of the regular board meeting held ' + date
+                board_report = Bill.objects.get(ocr_full_text__icontains=content, bill_type='Minutes')
+            except Bill.DoesNotExist:
                 return None
             else:
-                return doc.url
+                return '/board-report/' + board_report.slug
         else:
-            return '/board-report/' + board_report.slug
+            return doc.url
 
 
 class LAMetroEventMedia(EventMedia):

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -100,11 +100,13 @@
                             </p>
                             {% endif %}
                             {% if 'regular board meeting' in event.name|lower %}
-                                {% if event.ocd_id|get_minutes %}
-                                <p>
-                                    <a href="{{ event.ocd_id|get_minutes }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>
-                                </p>
-                                {% endif %}
+                                {% with minutes=event.event_minutes %}
+                                    {% if minutes %}
+                                    <p>
+                                        <a href="{{ minutes }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>
+                                    </p>
+                                    {% endif %}
+                                {% endwith %}
                             {% endif %}
                         {% endif %}
 

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -99,15 +99,15 @@
                                 </br>
                             </p>
                             {% endif %}
-                            {% if 'regular board meeting' in event.name|lower %}
-                                {% with minutes=event.event_minutes %}
-                                    {% if minutes %}
-                                    <p>
-                                        <a href="{{ minutes }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>
-                                    </p>
-                                    {% endif %}
-                                {% endwith %}
-                            {% endif %}
+
+                            {% with minutes=event.board_event_minutes %}
+                                {% if minutes %}
+                                <p>
+                                    <a href="{{ minutes }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>
+                                </p>
+                                {% endif %}
+                            {% endwith %}
+
                         {% endif %}
 
                         </div>

--- a/lametro/templates/partials/past_event_day.html
+++ b/lametro/templates/partials/past_event_day.html
@@ -53,14 +53,13 @@
         {% endif %}
     </div>
     <div class="col-xs-1">
-        {% if 'regular board meeting' in event.name|lower %}
-            {% if event.ocd_id|get_minutes %}
-            <p>
-                <a href="{{ event.ocd_id|get_minutes }}">Minutes</a>
-            </p>
-            {% endif %}
-        {% endif %}
-
+            {% with minutes=event.event_minutes %}
+                {% if minutes %}
+                <p>
+                    <a href="{{ minutes }}">Minutes</a>
+                </p>
+                {% endif %}
+            {% endwith %}
     </div>
     {% endif %}
 

--- a/lametro/templates/partials/past_event_day.html
+++ b/lametro/templates/partials/past_event_day.html
@@ -53,6 +53,7 @@
         {% endif %}
     </div>
     <div class="col-xs-1">
+        {% if 'regular board meeting' in event.name|lower %}
             {% with minutes=event.event_minutes %}
                 {% if minutes %}
                 <p>
@@ -60,6 +61,7 @@
                 </p>
                 {% endif %}
             {% endwith %}
+        {% endif %}
     </div>
     {% endif %}
 

--- a/lametro/templates/partials/past_event_day.html
+++ b/lametro/templates/partials/past_event_day.html
@@ -53,15 +53,13 @@
         {% endif %}
     </div>
     <div class="col-xs-1">
-        {% if 'regular board meeting' in event.name|lower %}
-            {% with minutes=event.event_minutes %}
-                {% if minutes %}
-                <p>
-                    <a href="{{ minutes }}">Minutes</a>
-                </p>
-                {% endif %}
-            {% endwith %}
-        {% endif %}
+        {% with minutes=event.board_event_minutes %}
+            {% if minutes %}
+            <p>
+                <a href="{{ minutes }}">Minutes</a>
+            </p>
+            {% endif %}
+        {% endwith %}
     </div>
     {% endif %}
 

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -119,28 +119,6 @@ def format_string(label_list):
     return label_list.split(',')
 
 @register.filter
-def get_minutes(event_id):
-    event = LAMetroEvent.objects.get(ocd_id=event_id)
-
-    doc = event.documents.filter(note__icontains='RBM Minutes').first()
-
-    if doc:
-        return doc.url
-    else:
-        date = event.start_time.date().strftime('%B %d, %Y')
-        content = 'minutes of the regular board meeting held ' + date
-        sqs = SearchQuerySet().filter(content=content).all()
-        if sqs:
-            for q in sqs:
-                if (q.object.bill_type == 'Minutes' and 
-                    q.object.slug and 
-                    q.object.ocr_full_text):
-                    if re.search(content, q.object.ocr_full_text, re.IGNORECASE):
-                        return '/board-report/' + q.object.slug
-        else:
-            return None
-
-@register.filter
 def compare_time(event_date):
     if event_date < timezone.now():
         return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,14 +31,14 @@ def bill(db, legislative_session):
                 'ocd_updated_at': '2017-06-09 13:06:21.10075-05',
                 'updated_at': '2017-07-26 11:06:47.1853',
                 'identifier': '2017-0686',
-                'slug': '2017-0686',
+                'slug': uuid4(),
                 '_legislative_session': legislative_session,
             }
 
             bill_info.update(kwargs)
 
             bill = LAMetroBill.objects.create(**bill_info)
-            bill.save()
+            bill.save
 
             return bill
 
@@ -69,7 +69,7 @@ def event(db):
                 'ocd_created_at': '2017-05-27 11:10:46.574-05',
                 'ocd_updated_at': '2017-05-27 11:10:46.574-05',
                 'name': 'System Safety, Security and Operations Committee',
-                'start_time': '2017-05-18 12:15:00-05',
+                'start_time': datetime.strptime('2017-05-18 12:15', '%Y-%m-%d %H:%M'), 
                 'updated_at': '2017-05-17 11:06:47.1853',
                 'slug': uuid4(),
             }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def bill(db, legislative_session):
                 'ocd_updated_at': '2017-06-09 13:06:21.10075-05',
                 'updated_at': '2017-07-26 11:06:47.1853',
                 'identifier': '2017-0686',
-                'slug': uuid4(),
+                'slug': '2017-0686',
                 '_legislative_session': legislative_session,
             }
 
@@ -55,7 +55,6 @@ def legislative_session(db):
     }
 
     session = LegislativeSession.objects.create(**session_info)
-    session.save()
 
     return session
 
@@ -77,7 +76,6 @@ def event(db):
             event_info.update(kwargs)
 
             event = LAMetroEvent.objects.create(**event_info)
-            event.save()
 
             return event
 
@@ -99,7 +97,6 @@ def event_agenda_item(db, event):
             event_agenda_item_info.update(kwargs)
 
             event_agenda_item = EventAgendaItem.objects.create(**event_agenda_item_info)
-            event_agenda_item.save()
 
             return event_agenda_item
 
@@ -120,7 +117,6 @@ def event_document(db):
             event_document_info.update(kwargs)
 
             event_document = EventDocument.objects.create(**event_document_info)
-            event_document.save()
 
             return event_document
 
@@ -186,7 +182,6 @@ def membership(db, metro_organization, metro_person):
             membership_info.update(kwargs)
 
             membership = Membership.objects.create(**membership_info)
-            membership.save()
 
             return membership
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,6 @@ def bill(db, legislative_session):
             bill_info.update(kwargs)
 
             bill = LAMetroBill.objects.create(**bill_info)
-            bill.save
 
             return bill
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -191,3 +191,31 @@ def test_current_meeting_no_potentially_current(event):
 
     # Assert we did not return any current meetings.
     assert not current_meetings
+
+@pytest.mark.parametrize('name', [
+        ('Construction Committee'),
+        ('Regular Board Meeting'),
+    ]
+)
+def test_event_minutes_none(event, name):
+    e_info = {
+        'name': name,
+    }
+    e = event.build(**e_info)
+
+    assert e.event_minutes == None
+
+# def test_event_minutes_bill(event, bill):
+#     b_info = {
+#         'bill_type': 'Minutes',
+#         'ocr_full_text': 'APPROVE Minutes of the Regular Board Meeting held May 18, 2017.',
+#     }
+#     b = bill.build(**b_info)
+    
+#     e_info = {
+#         'name': 'Regular Board Meeting',
+#     }
+#     e = event.build(**e_info)
+
+
+#     assert e.event_minutes == '/board-report/' + b.slug

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -205,17 +205,29 @@ def test_event_minutes_none(event, name):
 
     assert e.event_minutes == None
 
-# def test_event_minutes_bill(event, bill):
-#     b_info = {
-#         'bill_type': 'Minutes',
-#         'ocr_full_text': 'APPROVE Minutes of the Regular Board Meeting held May 18, 2017.',
-#     }
-#     b = bill.build(**b_info)
-    
-#     e_info = {
-#         'name': 'Regular Board Meeting',
-#     }
-#     e = event.build(**e_info)
+def test_event_minutes_bill(event, bill):
+    bill_info = {
+        'bill_type': 'Minutes',
+        'ocr_full_text': 'APPROVE Minutes of the Regular Board Meeting held May 18, 2017.',
+    }
+    bill_minutes = bill.build(**bill_info)
 
+    event_info = {
+        'name': 'Regular Board Meeting',
+    }
+    board_meeting = event.build(**event_info)
 
-#     assert e.event_minutes == '/board-report/' + b.slug
+    assert board_meeting.event_minutes == '/board-report/' + bill_minutes.slug
+
+def test_event_minutes_doc(event, event_document):
+    event_info = {
+        'name': 'Regular Board Meeting',
+    }
+    board_meeting = event.build(**event_info)
+
+    event_document_info = {
+        'note': '2017-06-22 RBM Minutes'
+    }
+    minutes_document = event_document.build(**event_document_info)
+
+    assert board_meeting.event_minutes == minutes_document.url

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -203,7 +203,7 @@ def test_event_minutes_none(event, name):
     }
     e = event.build(**e_info)
 
-    assert e.event_minutes == None
+    assert e.board_event_minutes == None
 
 def test_event_minutes_bill(event, bill):
     bill_info = {
@@ -217,7 +217,7 @@ def test_event_minutes_bill(event, bill):
     }
     board_meeting = event.build(**event_info)
 
-    assert board_meeting.event_minutes == '/board-report/' + bill_minutes.slug
+    assert board_meeting.board_event_minutes == '/board-report/' + bill_minutes.slug
 
 def test_event_minutes_doc(event, event_document):
     event_info = {
@@ -230,4 +230,4 @@ def test_event_minutes_doc(event, event_document):
     }
     minutes_document = event_document.build(**event_document_info)
 
-    assert board_meeting.event_minutes == minutes_document.url
+    assert board_meeting.board_event_minutes == minutes_document.url


### PR DESCRIPTION
## Overview

This PR revises our strategy for finding minutes associated with Board Meetings on the Events listview. 

Some events do not have corresponding minutes in an EventDocument: previously, we queried Solr to discover those minutes. Thanks to [updates in django-councilmatic](https://github.com/datamade/django-councilmatic/blob/master/councilmatic_core/management/commands/import_data.py#L986), the `ocr_full_text` contains what we need.

This PR also moves the `get_minutes` logic into the LAMetroEvent class, rather than a template tag. 

Altogether, this new approach saves us around 200 queries. 

## Testing Instructions

#### pytest
This PR includes three tests for three simple cases, i.e., when (1) `event_minutes` should return none, (2) `event_minutes` should return an EventDocument url, and (3) `event_minutes` should return a board report url. 

Execute `pytest tests/test_events.py`, and wait for tests to pass.

#### run the code
* `python manage.py runserver`
* visit http://127.0.0.1:8000/events/
* look for the Minutes hyperlink next to Board Meetings

Handles #233, but also relates to #403 