### PR TITLE
Displaying committee chair name

### DIFF
--- a/lametro/templates/lametro/committees.html
+++ b/lametro/templates/lametro/committees.html
@@ -33,7 +33,7 @@
                                 <td align="left">
                                     {% for person in committee %}
                                         {% if person.role == 'Chair' %}
-                                        <!-- "9" acts as a placeholder for "name", to account for duplicate fields in SQL call (line 64 of views.py) -->
+                                        <!-- "10" acts as a placeholder for "name", to account for duplicate fields in SQL call (line 64 of views.py) -->
                                             {{ person.10 }}
                                         {% endif %}
                                     {% endfor %}

--- a/lametro/templates/lametro/committees.html
+++ b/lametro/templates/lametro/committees.html
@@ -33,7 +33,6 @@
                                 <td align="left">
                                     {% for person in committee %}
                                         {% if person.role == 'Chair' %}
-                                        <!-- "10" acts as a placeholder for "name", to account for duplicate fields in SQL call (line 64 of views.py) -->
                                             {{ person.member_name }}
                                         {% endif %}
                                     {% endfor %}

--- a/lametro/templates/lametro/committees.html
+++ b/lametro/templates/lametro/committees.html
@@ -34,7 +34,7 @@
                                     {% for person in committee %}
                                         {% if person.role == 'Chair' %}
                                         <!-- "9" acts as a placeholder for "name", to account for duplicate fields in SQL call (line 64 of views.py) -->
-                                            {{ person.9 }}
+                                            {{ person.10 }}
                                         {% endif %}
                                     {% endfor %}
                                 </td>

--- a/lametro/templates/lametro/committees.html
+++ b/lametro/templates/lametro/committees.html
@@ -34,7 +34,7 @@
                                     {% for person in committee %}
                                         {% if person.role == 'Chair' %}
                                         <!-- "10" acts as a placeholder for "name", to account for duplicate fields in SQL call (line 64 of views.py) -->
-                                            {{ person.10 }}
+                                            {{ person.member_name }}
                                         {% endif %}
                                     {% endfor %}
                                 </td>

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -128,10 +128,10 @@ class LAMetroEventDetail(EventDetailView):
             return self.render_to_response(self.get_context_data(url_form=url_form, pdf_form=pdf_form))
 
     def get_object(self):
-        # Get the event with prefetched media_urls in proper order. 
+        # Get the event with prefetched media_urls in proper order.
         event = LAMetroEvent.objects.with_media().get(slug=self.kwargs['slug'])
-        
-        return event 
+
+        return event
 
     def get_context_data(self, **kwargs):
         context = super(EventDetailView, self).get_context_data(**kwargs)
@@ -202,8 +202,8 @@ class LAMetroEventDetail(EventDetailView):
                 obj = obj + (packet_url,)
 
                 # The cursor object potentially includes public and private bills.
-                # However, the LAMetroBillManager excludes private bills 
-                # from the LAMetroBill queryset. 
+                # However, the LAMetroBillManager excludes private bills
+                # from the LAMetroBill queryset.
                 # Attempting to `get` a private bill from LAMetroBill.objects
                 # raises a DoesNotExist error. As a precaution, we use filter()
                 # rather than get().
@@ -504,7 +504,7 @@ class LACommitteesView(CommitteesView):
         with connection.cursor() as cursor:
 
             sql = ('''
-              SELECT DISTINCT on (o.ocd_id, m.person_id) o.*, m.person_id, m.role, p.name
+              SELECT DISTINCT on (o.ocd_id, m.person_id) o.*, m.person_id, m.role, p.name AS member_name
               FROM councilmatic_core_organization AS o
               JOIN councilmatic_core_membership AS m
               ON o.ocd_id=m.organization_id


### PR DESCRIPTION
## Overview
This PR updates the Committees page to list the name of the Chairperson, not just the word 'Chair.'

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="825" alt="Screen Shot 2019-04-04 at 4 36 00 PM" src="https://user-images.githubusercontent.com/6961258/55590245-efb46a80-56f7-11e9-8b00-dac05ebd64fa.png">


### Notes

The time estimated for this was 6 hours, so I'm worried this is just a hack. The wrong field was being referenced (was `person.9` should be `person.10`), but maybe that's because one of the underlying models changed.


## Testing Instructions
The only change was in the template, so running `python manage.py runserver` should show the changes.

Handles #368 
