### PR TITLE
Re-integrate "Remove Solr dependency" changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Overview
+
+Brief description of what this PR does, and why it is needed.
+
+### Checklist
+
+- [ ] PR has a descriptive enough title to be useful in changelogs
+
+### Demo
+
+Optional. Screenshots, `curl` examples, etc.
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+
+## Testing Instructions
+
+ * How to test this PR
+ * Prefer bulleted description
+ * Start after checking out this branch
+ * Include any setup required, such as bundling scripts, restarting services, etc.
+ * Include test case, and expected output
+
+Handles #XXX

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -476,8 +476,8 @@ class LAMetroEvent(Event, LiveMediaMixin):
                 try:
                     date = self.start_time.date().strftime('%B %d, %Y')
                     content = 'minutes of the regular board meeting held ' + date
-                    board_report = Bill.objects.get(ocr_full_text__icontains=content, bill_type='Minutes')
-                except Bill.DoesNotExist:
+                    board_report = LAMetroBill.objects.get(ocr_full_text__icontains=content, bill_type='Minutes')
+                except LAMetroBill.DoesNotExist:
                     return None
                 else:
                     return '/board-report/' + board_report.slug

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -99,13 +99,15 @@
                                 </br>
                             </p>
                             {% endif %}
-                            {% if 'regular board meeting' in event.name|lower %}
-                                {% if event.ocd_id|get_minutes %}
+
+                            {% with minutes=event.board_event_minutes %}
+                                {% if minutes %}
                                 <p>
-                                    <a href="{{ event.ocd_id|get_minutes }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>
+                                    <a href="{{ minutes }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>
                                 </p>
                                 {% endif %}
-                            {% endif %}
+                            {% endwith %}
+
                         {% endif %}
 
                         </div>

--- a/lametro/templates/partials/past_event_day.html
+++ b/lametro/templates/partials/past_event_day.html
@@ -53,14 +53,13 @@
         {% endif %}
     </div>
     <div class="col-xs-1">
-        {% if 'regular board meeting' in event.name|lower %}
-            {% if event.ocd_id|get_minutes %}
+        {% with minutes=event.board_event_minutes %}
+            {% if minutes %}
             <p>
-                <a href="{{ event.ocd_id|get_minutes }}">Minutes</a>
+                <a href="{{ minutes }}">Minutes</a>
             </p>
             {% endif %}
-        {% endif %}
-
+        {% endwith %}
     </div>
     {% endif %}
 

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -119,28 +119,6 @@ def format_string(label_list):
     return label_list.split(',')
 
 @register.filter
-def get_minutes(event_id):
-    event = LAMetroEvent.objects.get(ocd_id=event_id)
-
-    doc = event.documents.filter(note__icontains='RBM Minutes').first()
-
-    if doc:
-        return doc.url
-    else:
-        date = event.start_time.date().strftime('%B %d, %Y')
-        content = 'minutes of the regular board meeting held ' + date
-        sqs = SearchQuerySet().filter(content=content).all()
-        if sqs:
-            for q in sqs:
-                if (q.object.bill_type == 'Minutes' and 
-                    q.object.slug and 
-                    q.object.ocr_full_text):
-                    if re.search(content, q.object.ocr_full_text, re.IGNORECASE):
-                        return '/board-report/' + q.object.slug
-        else:
-            return None
-
-@register.filter
 def compare_time(event_date):
     if event_date < timezone.now():
         return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,6 @@ def bill(db, legislative_session):
             bill_info.update(kwargs)
 
             bill = LAMetroBill.objects.create(**bill_info)
-            bill.save()
 
             return bill
 
@@ -55,7 +54,6 @@ def legislative_session(db):
     }
 
     session = LegislativeSession.objects.create(**session_info)
-    session.save()
 
     return session
 
@@ -69,7 +67,7 @@ def event(db):
                 'ocd_created_at': '2017-05-27 11:10:46.574-05',
                 'ocd_updated_at': '2017-05-27 11:10:46.574-05',
                 'name': 'System Safety, Security and Operations Committee',
-                'start_time': '2017-05-18 12:15:00-05',
+                'start_time': datetime.strptime('2017-05-18 12:15', '%Y-%m-%d %H:%M'), 
                 'updated_at': '2017-05-17 11:06:47.1853',
                 'slug': uuid4(),
             }
@@ -77,7 +75,6 @@ def event(db):
             event_info.update(kwargs)
 
             event = LAMetroEvent.objects.create(**event_info)
-            event.save()
 
             return event
 
@@ -99,7 +96,6 @@ def event_agenda_item(db, event):
             event_agenda_item_info.update(kwargs)
 
             event_agenda_item = EventAgendaItem.objects.create(**event_agenda_item_info)
-            event_agenda_item.save()
 
             return event_agenda_item
 
@@ -120,7 +116,6 @@ def event_document(db):
             event_document_info.update(kwargs)
 
             event_document = EventDocument.objects.create(**event_document_info)
-            event_document.save()
 
             return event_document
 
@@ -186,7 +181,6 @@ def membership(db, metro_organization, metro_person):
             membership_info.update(kwargs)
 
             membership = Membership.objects.create(**membership_info)
-            membership.save()
 
             return membership
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -191,3 +191,43 @@ def test_current_meeting_no_potentially_current(event):
 
     # Assert we did not return any current meetings.
     assert not current_meetings
+
+@pytest.mark.parametrize('name', [
+        ('Construction Committee'),
+        ('Regular Board Meeting'),
+    ]
+)
+def test_event_minutes_none(event, name):
+    e_info = {
+        'name': name,
+    }
+    e = event.build(**e_info)
+
+    assert e.board_event_minutes == None
+
+def test_event_minutes_bill(event, bill):
+    bill_info = {
+        'bill_type': 'Minutes',
+        'ocr_full_text': 'APPROVE Minutes of the Regular Board Meeting held May 18, 2017.',
+    }
+    bill_minutes = bill.build(**bill_info)
+
+    event_info = {
+        'name': 'Regular Board Meeting',
+    }
+    board_meeting = event.build(**event_info)
+
+    assert board_meeting.board_event_minutes == '/board-report/' + bill_minutes.slug
+
+def test_event_minutes_doc(event, event_document):
+    event_info = {
+        'name': 'Regular Board Meeting',
+    }
+    board_meeting = event.build(**event_info)
+
+    event_document_info = {
+        'note': '2017-06-22 RBM Minutes'
+    }
+    minutes_document = event_document.build(**event_document_info)
+
+    assert board_meeting.board_event_minutes == minutes_document.url

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -147,7 +147,6 @@ def test_current_meeting_no_streaming_event(concurrent_current_meetings,
     assert all(m in current_meetings for m in concurrent_current_meetings)
 
 
-@pytest.mark.dev
 def test_current_meeting_no_streaming_event_late_start(event, mocker):
     '''
     Test that if an meeting is scheduled but not yet streaming, it is returned
@@ -192,6 +191,7 @@ def test_current_meeting_no_potentially_current(event):
     # Assert we did not return any current meetings.
     assert not current_meetings
 
+
 @pytest.mark.parametrize('name', [
         ('Construction Committee'),
         ('Regular Board Meeting'),
@@ -205,19 +205,29 @@ def test_event_minutes_none(event, name):
 
     assert e.board_event_minutes == None
 
-def test_event_minutes_bill(event, bill):
+
+def test_event_minutes_bill(event_agenda_item, bill):
+    # The LAMetroBill manager will only return bills that appear on a published
+    # agenda. So, build the agenda item, and associate the bill and a board
+    # meeting with a published agenda.
+    agenda_item = event_agenda_item.build()
+
+    board_meeting = agenda_item.event
+    board_meeting.name = 'Regular Board Meeting'
+    board_meeting.status = 'passed'
+    board_meeting.save()
+
     bill_info = {
         'bill_type': 'Minutes',
         'ocr_full_text': 'APPROVE Minutes of the Regular Board Meeting held May 18, 2017.',
     }
     bill_minutes = bill.build(**bill_info)
 
-    event_info = {
-        'name': 'Regular Board Meeting',
-    }
-    board_meeting = event.build(**event_info)
+    agenda_item.bill = bill_minutes
+    agenda_item.save()
 
     assert board_meeting.board_event_minutes == '/board-report/' + bill_minutes.slug
+
 
 def test_event_minutes_doc(event, event_document):
     event_info = {


### PR DESCRIPTION
This PR is essentially a duplicate of #424, with two changes:

- Query the `LAMetroBill` model so links to private board reports containing minutes are not displayed in the UI.
- Update test state so the test minutes are returned when querying `LAMetroBill`.

Testing instructions:

- Pull down changes and import new data: `python manage.py import_data`. 
- Run the app locally, as described in the README.
- Navigate to the events page. Confirm that minutes are displayed for the March 28, 2019 board meeting, and that the link leads to an active page.