### PR TITLE
Add standalone page for Search Archive

### DIFF
--- a/councilmatic/settings_jurisdiction.py
+++ b/councilmatic/settings_jurisdiction.py
@@ -237,7 +237,7 @@ LEGISLATION_TYPE_DESCRIPTIONS = [
         'search_term': 'board box',
         'fa_icon': 'commenting-o',
         'html_desc': True,
-        'desc': "Formal information communication to the Board not requiring actions. We are in the process of importing Board Boxes to this website; in the meantime, please access Board Box items through the <a href='http://search3.metro.net/search?access=p&output=xml_no_dtd&site=Board_Archives&ie=UTF-8&client=BoardArchive&proxystylesheet=BoardArchive&proxycustom=%3CHOME/%3E' target='_blank'>Board Archive</a>."
+        'desc': "Formal information communication to the Board not requiring actions. We are in the process of importing Board Boxes to this website; in the meantime, please access Board Box items through the <a href='/archive-search' target='_blank'>Archive Search</a>."
     },
 ]
 

--- a/councilmatic/urls.py
+++ b/councilmatic/urls.py
@@ -12,7 +12,7 @@ from councilmatic_core.feeds import CouncilmaticFacetedSearchFeed
 from lametro.views import LAMetroIndexView, LAMetroEventDetail, LABillDetail, LABoardMembersView, \
     LAMetroAboutView, LACommitteeDetailView, LACommitteesView, LAPersonDetailView, \
     LAMetroEventsView, LAMetroCouncilmaticFacetedSearchView, GoogleView, \
-    metro_login, metro_logout, delete_submission
+    metro_login, metro_logout, delete_submission, LAMetroArchiveSearch
 from lametro.feeds import *
 
 patterns = ([
@@ -21,6 +21,7 @@ patterns = ([
     url(r'^search/', LAMetroCouncilmaticFacetedSearchView(searchqueryset=EmptySearchQuerySet,
                                                           form_class=CouncilmaticSearchForm),
                                                           name='search'),
+    url(r'^archive-search', LAMetroArchiveSearch.as_view(), name='archive-search'),
     url(r'^$', never_cache(LAMetroIndexView.as_view()), name='index'),
     url(r'^about/$', LAMetroAboutView.as_view(), name='about'),
     url(r'^board-report/(?P<slug>[^/]+)/$', LABillDetail.as_view(), name='bill_detail'),

--- a/lametro/templates/base.html
+++ b/lametro/templates/base.html
@@ -64,14 +64,7 @@
                         <a href="{% url 'lametro:search' %}">Board Reports</a>
                     </li>
                     <li>
-                      <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown">
-                        Archive Search
-                        <span class="caret"></span>
-                      </a>
-                        <ul class="dropdown-menu dropdown-menu-right">
-                          <li><a href="http://search3.metro.net/search?access=p&output=xml_no_dtd&site=Board_Archives&ie=UTF-8&client=BoardArchive&proxystylesheet=BoardArchive&proxycustom=%3CHOME/%3E" target="_blank">Board Reports (pre-May 2015)</a></li>
-                          <li><a href="http://search3.metro.net/search?output=xml_no_dtd&client=BoardBox&proxystylesheet=BoardBox&ie=UTF-8&site=BoardBox&access=p&proxycustom=%3CHOME/%3E" target="_blank">Board Box</a></li>
-                        </ul>
+                        <a href="{% url 'lametro:archive-search' %}">Archive Search</a>
                     </li>
                     {% nocache %}
                     <li>

--- a/lametro/templates/lametro/archive_search.html
+++ b/lametro/templates/lametro/archive_search.html
@@ -1,0 +1,20 @@
+{% extends "base_with_margins.html" %}
+{% load staticfiles %}
+{% load adv_cache %}
+{% block title %}Archive Search{% endblock %}
+
+{% block content %}
+<gcse:search></gcse:search>
+
+<script>
+  (function() {
+    var cx = '007602828488985387677:mhzmxh6ty20';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+{% endblock %}

--- a/lametro/templates/lametro/archive_search.html
+++ b/lametro/templates/lametro/archive_search.html
@@ -1,11 +1,33 @@
-{% extends "base_with_margins.html" %}
+{% extends "base.html" %}
 {% load staticfiles %}
 {% load adv_cache %}
 {% block title %}Archive Search{% endblock %}
 
-{% block content %}
-<gcse:search></gcse:search>
+{% block full_content %}
+<div class="container-fluid">
+  <div class="col-sm-12">
+  <div class="row-fluid">
+    <br />
+    <div class="col-sm-9 no-pad-mobile">
+      <h1>Archive Search <small>Metro’s Board Records from 1993-2015</small></h1>
+      <gcse:search></gcse:search>
+    </div>
+    <div class="col-sm-3 no-pad-mobile">
+      <div class="well info-blurb">
+        <h4><i class="fa fa-fw fa-info-circle"></i> What's this?</h4>
 
+        <p>Search the LACMTA Board of Directors records from 1993 to 2015. Also includes Meeting Minutes for Metro predecessor public agencies: Los Angeles Metropolitan Transit Authority (LAMTA 1951-1964, incomplete), Southern California Rapid Transit District (SCRTD 1964-1993), Los Angeles County Transportation Commission (LACTC 1977-1993) and Rail Construction Corporation (RCC 1989-1993).</p>
+
+        <p>Subcategories to refine your search will appear just below the search box after a search is initiated.</p>
+
+        <p>Looking for Board records from 2015 to present? <a href="{% url 'lametro:search' %}">Search current records &raquo;</a></p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
 <script>
   (function() {
     var cx = '007602828488985387677:mhzmxh6ty20';

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -29,7 +29,7 @@
                         </label>
                     </div>
                 </form><br />
-                <p class="archive-link"><a href="http://search3.metro.net/search?access=p&output=xml_no_dtd&site=Board_Archives&ie=UTF-8&client=BoardArchive&proxystylesheet=BoardArchive&proxycustom=%3CHOME/%3E" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> Search the Metro Board Archive (1952-2015)</a></p>
+                <p class="archive-link"><a href="{% url 'lametro:archive-search' %}">Search the Metro Board Archive (1952-2015)</a></p>
             </div>
         </div>
     </div>

--- a/lametro/templates/partials/empty_search_message.html
+++ b/lametro/templates/partials/empty_search_message.html
@@ -1,5 +1,5 @@
 <p>
-  This site has Board Reports and Agendas from June 2015 to present. If you're searching for something older, you can browse the <a href="http://search3.metro.net/search?access=p&output=xml_no_dtd&site=Board_Archives&ie=UTF-8&client=BoardArchive&proxystylesheet=BoardArchive&proxycustom=%3CHOME/%3E" target="_blank">Board Archive</a>.
+  This site has Board Reports and Agendas from June 2015 to present. If you're searching for something older, you can browse the <a href="{% url 'lametro:archive-search' %}">Archive Search</a>.
 </p>
 <p>We'd be happy to help you find what you're looking for! Contact us at
   <a href="mailto:boardreport@metro.net">boardreport@metro.net</a>

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -25,6 +25,7 @@ from django.db.models.functions import Lower
 from django.db.models import Max, Min, Prefetch
 from django.utils import timezone
 from django.utils.text import slugify
+from django.views.generic import TemplateView
 from django.http import HttpResponse, HttpResponseRedirect, HttpResponsePermanentRedirect, HttpResponseNotFound
 from django.shortcuts import render_to_response, redirect
 from django.core import management
@@ -773,6 +774,10 @@ class LAMetroCouncilmaticFacetedSearchView(CouncilmaticFacetedSearchView):
 
 class GoogleView(IndexView):
     template_name = 'lametro/google66b34bb6957ad66c.html'
+
+
+class LAMetroArchiveSearch(TemplateView):
+    template_name = 'lametro/archive_search.html'
 
 
 def metro_login(request):


### PR DESCRIPTION
## Overview

Google Search Appliance is dead (long live Google Search Appliance), which means the Archive Search links in the header are broken. This PR adds a standalone page to host Metro's custom Google search engine, in order to facilitate searching the archive. It also points the top-nav link to this page, and updates references to the dead links throughout the site.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="1440" alt="Screen Shot 2019-05-14 at 3 39 09 PM" src="https://user-images.githubusercontent.com/12176173/57731063-75182c80-765f-11e9-81f2-2be6837505a7.png">
<img width="1440" alt="Screen Shot 2019-05-14 at 3 39 18 PM" src="https://user-images.githubusercontent.com/12176173/57731062-75182c80-765f-11e9-976b-4c0bbd09f0be.png">

### Notes

N/A

## Testing Instructions

- Run the app
- Confirm that the links on to the search archive work on the following pages:
  - Homepage
  - About page
  - Search page
- Click "Search Archive" and confirm that things look and behave as expected

Handles #435.