### PR TITLE
Adding information about livestream to homepage when there is not a meeting in session

### DIFF
--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -28,6 +28,10 @@ h1, .h1 {
   padding: 19.5px 10px;
 }
 
+#no-sessions {
+  padding-top: 3px;
+}
+
 .site-intro-search { margin-bottom: 1em; }
 
 #section-photo {

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -22,6 +22,11 @@
                       <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a"}}<br/>
                       <i class="fa fa-fw fa-map-marker"></i> {{ meeting.location_name}}<br />
                   </p>
+                  {% if meeting.documents.all %}
+                    <div class="col-xs-7">
+                      <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{meeting.documents.all|find_agenda_url}}'><i class='fa fa-fw fa-download'></i> Get Agenda PDF</a>
+                    </div>
+                  {% endif %}
                 </div>
               </div>
             </div>
@@ -32,11 +37,7 @@
             <p class="small" style="padding-top: 10px;"><strong>No meetings are in session at this time. The links to watch a meeting live, in English or Spanish, will be posted here once the meeting begins.</strong></p>
 
             <!-- Links to media url and PDF download -->
-            {% if meeting.documents.all %}
-              <div class="col-xs-7">
-                <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{meeting.documents.all|find_agenda_url}}'><i class='fa fa-fw fa-download'></i> Get Agenda PDF</a>
-              </div>
-            {% else %}
+            {% if not meeting.documents.all %}
               <p class="small"><em>Agenda will be posted no later than 72 hours prior to the start of the meeting, or 24 hours for Special Board meetings.</em></p>
             {% endif %}
 

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -6,42 +6,41 @@
         <div class="row" style="margin-top: 1em;">
             <div class="col-xs-6">
                 <img src='/static/images/Gateway03RT.jpg' class='img-responsive img-rounded' title='Los Angeles Gateway Plaza' alt="Los Angeles Gateway Plaza" />
-                <p id="no-sessions" class="small"><strong>No meetings are in session at this time. The links to watch a meeting live, in English or Spanish, will be posted here once the meeting begins.</strong></p>
             </div>
             <div class="col-xs-6">
-                <div class="row">
-                  <div class="col-xs-12">
-                    <!-- Meeting name -->
-                    <h4>
-                      {{  meeting.link_html | safe }}<br/>
-                      <span class="small text-muted">{{ meeting.description }}</span>
-                    </h4>
+              <div class="row">
+                <div class="col-xs-12">
+                  <!-- Meeting name -->
+                  <h4>
+                    {{  meeting.link_html | safe }}<br/>
+                    <span class="small text-muted">{{ meeting.description }}</span>
+                  </h4>
 
-                    <!-- Meeting info -->
-                    <p class="small text-muted">
-                        <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y"}}<br/>
-                        <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a"}}<br/>
-                        <i class="fa fa-fw fa-map-marker"></i> {{ meeting.location_name}}<br />
-                    </p>
-
-                    <!-- Links to media url and PDF download -->
-                    <div class="row">
-                        {% if meeting.documents.all %}
-                          <div class="col-xs-7">
-                            <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{meeting.documents.all|find_agenda_url}}'><i class='fa fa-fw fa-download'></i> Get Agenda PDF</a>
-                          </div>
-                        {% else %}
-                          <br>
-                          <p class="small"><em>Agenda will be posted no later than 72 hours prior to the start of the meeting, or 24 hours for Special Board meetings.</em></p>
-                        {% endif %}
-
-                    </div>
-
-                  </div>
+                  <!-- Meeting info -->
+                  <p class="small text-muted">
+                      <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y"}}<br/>
+                      <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a"}}<br/>
+                      <i class="fa fa-fw fa-map-marker"></i> {{ meeting.location_name}}<br />
+                  </p>
                 </div>
-                </br>
+              </div>
             </div>
+        </div>
 
+        <div class="row">
+          <div class="col-xs-12">
+            <p class="small" style="padding-top: 10px;"><strong>No meetings are in session at this time. The links to watch a meeting live, in English or Spanish, will be posted here once the meeting begins.</strong></p>
+
+            <!-- Links to media url and PDF download -->
+            {% if meeting.documents.all %}
+              <div class="col-xs-7">
+                <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{meeting.documents.all|find_agenda_url}}'><i class='fa fa-fw fa-download'></i> Get Agenda PDF</a>
+              </div>
+            {% else %}
+              <p class="small"><em>Agenda will be posted no later than 72 hours prior to the start of the meeting, or 24 hours for Special Board meetings.</em></p>
+            {% endif %}
+
+          </div>
         </div>
     </div>
 </div>

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -2,46 +2,49 @@
 {% load lametro_extras %}
 
 <div>
-    <div>
-        <div class="row" style="margin-top: 1em;">
-            <div class="col-xs-6">
-                <img src='/static/images/Gateway03RT.jpg' class='img-responsive img-rounded' title='Los Angeles Gateway Plaza' alt="Los Angeles Gateway Plaza" />
-            </div>
-            <div class="col-xs-6">
-              <div class="row">
-                <div class="col-xs-12">
-                  <!-- Meeting name -->
-                  <h4>
-                    {{  meeting.link_html | safe }}<br/>
-                    <span class="small text-muted">{{ meeting.description }}</span>
-                  </h4>
-
-                  <!-- Meeting info -->
-                  <p class="small text-muted">
-                      <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y"}}<br/>
-                      <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a"}}<br/>
-                      <i class="fa fa-fw fa-map-marker"></i> {{ meeting.location_name}}<br />
-                  </p>
-                  {% if meeting.documents.all %}
-                    <div class="col-xs-7">
-                      <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{meeting.documents.all|find_agenda_url}}'><i class='fa fa-fw fa-download'></i> Get Agenda PDF</a>
-                    </div>
-                  {% endif %}
-                </div>
-              </div>
-            </div>
-        </div>
-
+  <div>
+    <div class="row" style="margin-top: 1em;">
+      <div class="col-xs-6">
+        <img src='/static/images/Gateway03RT.jpg' class='img-responsive img-rounded' title='Los Angeles Gateway Plaza' alt="Los Angeles Gateway Plaza" />
+      </div>
+      <div class="col-xs-6">
         <div class="row">
           <div class="col-xs-12">
-            <p class="small" style="padding-top: 10px;"><strong>No meetings are in session at this time. The links to watch a meeting live, in English or Spanish, will be posted here once the meeting begins.</strong></p>
+            <!-- Meeting name -->
+            <h4>
+              {{  meeting.link_html | safe }}<br/>
+              <span class="small text-muted">{{ meeting.description }}</span>
+            </h4>
 
-            <!-- Links to media url and PDF download -->
-            {% if not meeting.documents.all %}
-              <p class="small"><em>Agenda will be posted no later than 72 hours prior to the start of the meeting, or 24 hours for Special Board meetings.</em></p>
-            {% endif %}
+            <!-- Meeting info -->
 
+            <p class="small text-muted">
+              <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y"}}<br/>
+              <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a"}}<br/>
+              <i class="fa fa-fw fa-map-marker"></i> {{ meeting.location_name}}<br />
+            </p>
+            {% if meeting.documents.all %}
+            <div class="row">
+              <div class="col-xs-7">
+                <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{meeting.documents.all|find_agenda_url}}'><i class='fa fa-fw fa-download'></i> Get Agenda PDF</a>
+              </div>
+              {% endif %}
+            </div>
           </div>
         </div>
+      </div>
     </div>
+
+    <div class="row">
+      <div class="col-xs-12">
+        <p class="small" style="padding-top: 10px;"><strong>No meetings are in session at this time. The links to watch a meeting live, in English or Spanish, will be posted here once the meeting begins.</strong></p>
+
+        <!-- Links to media url and PDF download -->
+        {% if not meeting.documents.all %}
+        <p class="small"><em>Agenda will be posted no later than 72 hours prior to the start of the meeting, or 24 hours for Special Board meetings.</em></p>
+        {% endif %}
+
+      </div>
+    </div>
+  </div>
 </div>

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -32,6 +32,7 @@
                         {% else %}
                           <br>
                           <p class="small"><em>Agenda will be posted no later than 72 hours prior to the start of the meeting, or 24 hours for Special Board meetings.</em></p>
+                          <p><strong>No meetings are in session at this time, The links to watch a meeting live, in English or Spanish, will be posted here once the meeting begins.</strong></p>
                         {% endif %}
 
                     </div>

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -6,6 +6,7 @@
         <div class="row" style="margin-top: 1em;">
             <div class="col-xs-6">
                 <img src='/static/images/Gateway03RT.jpg' class='img-responsive img-rounded' title='Los Angeles Gateway Plaza' alt="Los Angeles Gateway Plaza" />
+                <p id="no-sessions" class="small"><strong>No meetings are in session at this time. The links to watch a meeting live, in English or Spanish, will be posted here once the meeting begins.</strong></p>
             </div>
             <div class="col-xs-6">
                 <div class="row">
@@ -32,7 +33,6 @@
                         {% else %}
                           <br>
                           <p class="small"><em>Agenda will be posted no later than 72 hours prior to the start of the meeting, or 24 hours for Special Board meetings.</em></p>
-                          <p><strong>No meetings are in session at this time, The links to watch a meeting live, in English or Spanish, will be posted here once the meeting begins.</strong></p>
                         {% endif %}
 
                     </div>

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -28,8 +28,8 @@
               <div class="col-xs-7">
                 <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{meeting.documents.all|find_agenda_url}}'><i class='fa fa-fw fa-download'></i> Get Agenda PDF</a>
               </div>
-              {% endif %}
             </div>
+            {% endif %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Overview

This PR adds in text to explain where to find a livestream for the next board meeting when there isn't one currently in session.

### Checklist

- [ ] PR has a descriptive enough title to be useful in changelogs

### Demo

When there is an upcoming meeting scheduled...
<img width="1280" alt="Screen Shot 2019-05-28 at 11 29 49 AM" src="https://user-images.githubusercontent.com/6961258/58494996-f7aeea80-813b-11e9-888e-37e52fe7c5b3.png">

Switching out the partial for `meeting_details_current.html`, we can see the text is replaced by a link to the live stream.

<img width="1280" alt="Screen Shot 2019-05-28 at 11 35 12 AM" src="https://user-images.githubusercontent.com/6961258/58495330-d5699c80-813c-11e9-93ca-68366652ccfb.png">


## Testing Instructions

The notice should be visible on the homepage.

Handles #440 
