### PR TITLE
Visually groups links on Meetings page

### DIFF
--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -247,7 +247,7 @@ div#toggleControls { margin-bottom: 1em; }
 }
 
 hr {
-  margin: 10px 0px 15px 0px;
+  margin: 10px 15px 15px 15px;
 }
 
 

--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -239,7 +239,7 @@ div#toggleControls { margin-bottom: 1em; }
 
 /* Styles for events page */
 .divider {
-  border-width: 1px 0px;
+  border-width: 1px 0px 0px 0px;
   border-style: solid;
   border-color: #777777;
 }

--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -237,6 +237,13 @@ div#toggleControls { margin-bottom: 1em; }
     margin-bottom: 14px;
 }
 
+/* Styles for events page */
+.divider {
+  border-width: 1px 0px;
+  border-style: solid;
+  border-color: #777777;
+}
+
 
 /* Media queries */
 @media only screen and (max-width : 767px) {

--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -246,7 +246,7 @@ div#toggleControls { margin-bottom: 1em; }
   margin-bottom: 20px;
 }
 
-hr {
+hr .events-line {
   margin: 10px 15px 15px 15px;
 }
 

--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -239,9 +239,15 @@ div#toggleControls { margin-bottom: 1em; }
 
 /* Styles for events page */
 .divider {
-  border-width: 1px 0px 0px 0px;
+  border-width: 0px 0px 1px 0px;
   border-style: solid;
-  border-color: #777777;
+  border-color: rgba(119, 119, 119);
+  padding-bottom: 20px;
+  margin-bottom: 20px;
+}
+
+hr {
+  margin: 10px 0px 15px 0px;
 }
 
 

--- a/lametro/templates/lametro/events.html
+++ b/lametro/templates/lametro/events.html
@@ -64,7 +64,7 @@
                 <a href="" class="btn btn-salmon" id="more-upcoming-events"><i class="fa fa-fw fa-chevron-down"></i>Show all upcoming meetings</a>
                 <a href="" class="btn btn-salmon" id="fewer-upcoming-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer upcoming meetings</a>
 
-                <h2><span>Past {{ CITY_VOCAB.EVENTS }}</span>
+                <h2 style="margin-top: 40px;"><span>Past {{ CITY_VOCAB.EVENTS }}</span>
                 <br class="non-desktop-only"/>
                 <small><a href="rss/" title="RSS feed for Upcoming and Recent Events"><i class="fa fa-rss-square" aria-hidden="true"></i></a></small>
                 </h2>

--- a/lametro/templates/lametro/events.html
+++ b/lametro/templates/lametro/events.html
@@ -13,7 +13,7 @@
             <div id="events-form" class="row">
                 <div class="col-xs-8">
                     <form action='/events' method='GET'>
-                        
+
                       <div class="input-group" id='date-search'>
                             <span class="input-group-addon" id="sizing-addon3"><i class="fa fa-calendar" aria-hidden="true"></i></span>
                             <input type="text" id="from" name="from" class="form-control date-filter" placeholder="Select start date..." value='{{ start_date }}'>
@@ -37,7 +37,7 @@
             <div class="row">
                 <div class="col-md-10">
                     <div class="well login">
-                        <h4>Hello, {{ user.username }}!</h4> 
+                        <h4>Hello, {{ user.username }}!</h4>
                         <p>You have the authority to add agenda links to relevant events. Please click on an event that needs an agenda, and look for the URL input box.</p>
                         <p><em>You only have this option for events without agendas.</em></p>
                     </div>
@@ -55,8 +55,6 @@
                     <div class='col-sm-8' id='events_message'></div>
                 </div>
 
-                <hr/>
-
                 {% for date, event_list in future_events %}
                     <div class="event-upcoming-listing">
                         {% include "partials/event_day.html" %}
@@ -66,8 +64,6 @@
                 <a href="" class="btn btn-salmon" id="more-upcoming-events"><i class="fa fa-fw fa-chevron-down"></i>Show all upcoming meetings</a>
                 <a href="" class="btn btn-salmon" id="fewer-upcoming-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer upcoming meetings</a>
 
-                <hr/>
-
                 <h2><span>Past {{ CITY_VOCAB.EVENTS }}</span>
                 <br class="non-desktop-only"/>
                 <small><a href="rss/" title="RSS feed for Upcoming and Recent Events"><i class="fa fa-rss-square" aria-hidden="true"></i></a></small>
@@ -76,8 +72,6 @@
                 <div class='row'>
                     <div class='col-sm-8' id='events_message'></div>
                 </div>
-
-                <hr/>
 
                 {% for date, event_list in past_events %}
                     <div class='event-listing'>
@@ -98,8 +92,6 @@
                     <div class='col-sm-8' id='events_message'></div>
                 </div>
 
-                <hr/>
-
                 {% for date, event_list in select_events %}
                     {% include "partials/past_event_day.html" %}
                 {% endfor %}
@@ -113,8 +105,6 @@
                 <div class='row'>
                     <div class='col-sm-8' id='events_message'></div>
                 </div>
-
-                <hr/>
 
                 {% for date, event_list in all_events %}
                     {% include "partials/past_event_day.html" %}
@@ -178,7 +168,7 @@
 
         collapseEvents();
         collapseUpcomingEvents();
-        
+
         $("#more-upcoming-events").click(function() {
             expandUpcomingEvents();
             return false;

--- a/lametro/templates/partials/event_day.html
+++ b/lametro/templates/partials/event_day.html
@@ -1,0 +1,8 @@
+<h5 class="text-default">
+  <i class="fa fa-fw fa-calendar-o"></i> {{date | date:"D m/d/Y"}}
+  <div class="divider" />
+</h5>
+
+{% for event in event_list %}
+  {% include "partials/event_time_item.html" %}
+{% endfor %}

--- a/lametro/templates/partials/event_day.html
+++ b/lametro/templates/partials/event_day.html
@@ -1,6 +1,6 @@
 <h5 class="text-default">
   <i class="fa fa-fw fa-calendar-o"></i> {{date | date:"D m/d/Y"}}
-  <div class="divider" />
+  <div class="divider"></div>
 </h5>
 
 {% for event in event_list %}

--- a/lametro/templates/partials/event_time_item.html
+++ b/lametro/templates/partials/event_time_item.html
@@ -8,7 +8,7 @@
   {% endif %}
 
   {% if not forloop.first %}
-    <hr />
+    <hr class="events-line"/>
   {% endif %}
         <div class="col-xs-3 no-pad-right">
 

--- a/lametro/templates/partials/event_time_item.html
+++ b/lametro/templates/partials/event_time_item.html
@@ -1,9 +1,17 @@
 {% load lametro_extras %}
 
 <a href="{{event.event_page_url}}">
-    <div class="row">
+  {% if forloop.last %}
+  <div class="row" style="margin-bottom: 30px;">
+  {% else %}
+  <div class="row">
+  {% endif %}
+
+  {% if not forloop.first %}
+    <hr />
+  {% endif %}
         <div class="col-xs-3 no-pad-right">
-            
+
             {% if event.status == 'cancelled' %}<strike>{% endif %}
 
             <p class="small">
@@ -21,7 +29,7 @@
         <div class="col-xs-9">
             <p>
                 {% if event.status == 'cancelled' %}
-                    <strike>{{event.name}}</strike> 
+                    <strike>{{event.name}}</strike>
                     <span class="label label-stale">Cancelled</span>
                     <br/>
                 {% else %}

--- a/lametro/templates/partials/past_event_day.html
+++ b/lametro/templates/partials/past_event_day.html
@@ -5,7 +5,7 @@
 </h5>
 
 {% for event in event_list %}
-<div class="row">
+<div class="row divider">
     <div class="col-xs-3 no-pad-right">
 
         {% if event.status == 'cancelled' %}<strike>{% endif %}

--- a/lametro/templates/partials/past_event_day.html
+++ b/lametro/templates/partials/past_event_day.html
@@ -2,7 +2,7 @@
 
 <h5 class="text-default">
     <i class="fa fa-fw fa-calendar-o"></i> {{date | date:"D m/d/Y"}}
-    <div class="divider" />
+    <div class="divider"></div>
 </h5>
 {% for event in event_list %}
 
@@ -13,9 +13,9 @@
   {% endif %}
 
   {% if not forloop.first %}
-    <hr />
+    <hr class="events-line" />
   {% endif %}
-  
+
     <div class="col-xs-3 no-pad-right">
 
         {% if event.status == 'cancelled' %}<strike>{% endif %}

--- a/lametro/templates/partials/past_event_day.html
+++ b/lametro/templates/partials/past_event_day.html
@@ -15,6 +15,7 @@
   {% if not forloop.first %}
     <hr />
   {% endif %}
+  
     <div class="col-xs-3 no-pad-right">
 
         {% if event.status == 'cancelled' %}<strike>{% endif %}

--- a/lametro/templates/partials/past_event_day.html
+++ b/lametro/templates/partials/past_event_day.html
@@ -2,10 +2,19 @@
 
 <h5 class="text-default">
     <i class="fa fa-fw fa-calendar-o"></i> {{date | date:"D m/d/Y"}}
+    <div class="divider" />
 </h5>
-
 {% for event in event_list %}
-<div class="row divider">
+
+  {% if forloop.last %}
+  <div class="row" style="margin-bottom: 30px;">
+  {% else %}
+  <div class="row">
+  {% endif %}
+
+  {% if not forloop.first %}
+    <hr />
+  {% endif %}
     <div class="col-xs-3 no-pad-right">
 
         {% if event.status == 'cancelled' %}<strike>{% endif %}


### PR DESCRIPTION
## Overview

This PR adjusts the styles on the Events page, in order to better visually group associated links.

### Checklist

- [ ] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="1280" alt="Screen Shot 2019-05-30 at 10 04 05 AM" src="https://user-images.githubusercontent.com/6961258/58642247-906f7280-82c2-11e9-9b3a-323c86e7820c.png">

Mobile:
<img width="436" alt="Screen Shot 2019-05-30 at 10 43 53 AM" src="https://user-images.githubusercontent.com/6961258/58644932-f3afd380-82c7-11e9-898a-a3122546db55.png">
<img width="437" alt="Screen Shot 2019-05-30 at 10 44 21 AM" src="https://user-images.githubusercontent.com/6961258/58644933-f3afd380-82c7-11e9-82a1-fe9dfa8654ae.png">

### Notes

## Testing Instructions
* Pull down the branch
* Hard refresh your page to make sure the style changes are seen
* Play with different pages sizes to make sure the changes are responsive

Handles #308 
