### PR TITLE
Changing search title to 'Search Reports'

### DIFF
--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -1,0 +1,8 @@
+{% extends "search/search.html" %}
+{% block title %}
+    {% if request.GET.q %}
+        Search results for '{{ request.GET.q }}'
+    {% else %}
+        Search Reports
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Overview

This PR customizes the default Councilmatic search page title to say "Search Reports" instead of "Search Legistlation."

### Checklist

- [ ] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="189" alt="Screen Shot 2019-06-06 at 9 39 53 AM" src="https://user-images.githubusercontent.com/6961258/59041866-13eb0f80-883f-11e9-842c-e86a8904b1cf.png">



### Notes

This should be merged in after the autocomplete branch, because that one creates the `search.html` page.

Handles #449 
