### PR TITLE
Add small fixes to autocomplete search functionality

### DIFF
--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -325,3 +325,8 @@ div#toggleControls { margin-bottom: 1em; }
         float:none;
     }
 }
+
+.badge-highlight {
+    background-color: #d9edf7;
+    font-weight: normal;
+}

--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -328,5 +328,5 @@ div#toggleControls { margin-bottom: 1em; }
 
 .badge-highlight {
     background-color: #d9edf7;
-    font-weight: normal;
+    font-weight: 900;
 }

--- a/lametro/static/js/autocomplete.js
+++ b/lametro/static/js/autocomplete.js
@@ -60,7 +60,7 @@ function autocompleteSearchBar(element) {
         $.get('/topic/', { 'guid': suggestion.data })
       ).then(function(response) {
         if (response.status_code == 200) {
-          var base = '/search/?selected_facets=topics_exact%3A';
+          var base = '/search/?q=';
           var url = base + response.subject_safe;
           window.location.href = url;
         };

--- a/lametro/templates/base.html
+++ b/lametro/templates/base.html
@@ -106,15 +106,14 @@
     <script type="text/javascript">
         $('label.btn.btn-search-option').click(function toggleRadio(e) {
             // Toggle "active" appearance first, so filtering on active works.
-            // .button docs: https://getbootstrap.com/docs/3.3/javascript/#buttons
-            $(this).button('toggle');
+            $('label.btn.btn-search-option.active').removeClass('active');
+            $(this).addClass('active');
 
             var selected_input = $(this).children('input')[0];
             $(selected_input).attr('checked', true);
 
-            var unselected_input = $('label.btn').not('.active')
-                                                 .children('input')[0];
-            $(unselected_input).removeAttr('checked');
+            var unselected_input = $('label.btn').not('.active').children('input')[0];
+            $(unselected_input).attr('checked', false);
         });
     </script>
 

--- a/lametro/templates/partials/tags.html
+++ b/lametro/templates/partials/tags.html
@@ -1,4 +1,5 @@
 {% load extras %}
+{% load lametro_extras %}
 <p class="small text-muted condensed">
   <i class="fa fa-fw fa-calendar-o"></i> {{result.object.get_last_action_date|date:'n/d/Y'}} - {{result.object.current_action.description | remove_action_subj }} (most recent action)
 </p>
@@ -17,7 +18,7 @@
         <i class="fa fa-fw fa-tag"></i>
         {% for tag in result.object.topics %}
             {% with "topics_exact:"|add:tag as tag_facet %}
-            <span class="badge badge-muted pseudo-topic-tag">
+            <span class="badge {% if tag|matches_query:request %}badge-highlight{% else %}badge-muted{% endif %} pseudo-topic-tag">
                 <a href="{% search_with_querystring request selected_facets=tag_facet %}">{{tag}}</a>
             </span>&nbsp;
             {% endwith %}

--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -1,6 +1,279 @@
 {% extends "search/search.html" %}
 
 {% load staticfiles %}
+{% load extras %}
+
+{% block content %}
+
+    <br/>
+    <div class='jumbotron' id='search-jumbotron'>
+        <!-- Add partial, so the title above search can be easily customized for site. -->
+        {% include 'partials/search_header.html' %}
+
+        <form method="get" action=".">
+            <div class="input-group site-intro-search">
+
+                {% for facet, selections in selected_facets.items %}
+                    {% for s in selections %}
+                        <input name="selected_facets" type="hidden" class="form-control" value="{{facet}}_exact:{{s}}">
+                    {% endfor %}
+                {% endfor %}
+
+                {% if 'sort_by=date' in request.get_full_path %}
+                    <input name="sort_by" type="hidden" class="form-control" value="date">
+                {% endif %}
+
+                {% if 'sort_by=title' in request.get_full_path %}
+                    <input name="sort_by" type="hidden" class="form-control" value="title">
+                {% endif %}
+
+                {% if 'sort_by=relevance' in request.get_full_path %}
+                    <input name="sort_by" type="hidden" class="form-control" value="relevance">
+                {% endif %}
+
+                {% if 'order_by=asc' in request.get_full_path %}
+                    <input name="order_by" type="hidden" class="form-control" value="asc">
+                {% endif %}
+
+                {% if 'order_by=desc' in request.get_full_path %}
+                    <input name="order_by" type="hidden" class="form-control" value="desc">
+                {% endif %}
+
+                {% with formatted_q=request.GET.q|remove_question %}
+                    {% include 'partials/search_bar.html' %}
+                {% endwith %}
+            </div>
+        </form>
+    </div>
+
+    <div class="row" style="margin-left:unset;">
+        <div class="col-sm-4">
+            <p id="result-type-filter">
+                Result type:
+                <a class="btn btn-primary btn-sm{% if 'result_type' not in request.get_full_path or 'result_type=all' in request.get_full_path %} active{% endif %}" href="{% search_with_querystring request q=request.GET.q|remove_question result_type='all' %}">All</a>
+                <a class="btn btn-primary btn-sm{% if 'result_type=keyword' in request.get_full_path  %} active{% endif %}" href="{% search_with_querystring request result_type='keyword' %}">Keyword only</a>
+                <a class="btn btn-primary btn-sm{% if 'result_type=topic' in request.get_full_path %} active{% endif %}" href="{% search_with_querystring request result_type='topic' %}">Topic only</a>
+            </p>
+
+            {% if selected_facets %}
+                <p>
+                    <a href="/search/" class="btn btn-sm btn-default">
+                    <i class='fa fa-times'></i>
+                    Clear all filters
+                    </a>
+                </p>
+            {% endif %}
+
+            <!-- Legislation Status -->
+            {% with facet_name='inferred_status' facet_label='Status' item_list=facets.fields.inferred_status selected_list=selected_facets.inferred_status %}
+                {% include 'partials/search_filter.html' %}
+            {% endwith %}
+
+
+            <!-- Legislation Type -->
+            {% with facet_name='bill_type' facet_label='Legislation Type' item_list=facets.fields.bill_type selected_list=selected_facets.bill_type %}
+                {% include 'partials/search_filter.html' %}
+            {% endwith %}
+
+
+            <!-- Topic -->
+            {% if facets.fields.topics %}
+                {% with facet_name='topics' facet_label='Topic' item_list=facets.fields.topics selected_list=selected_facets.topics %}
+                    {% include 'partials/search_filter.html' %}
+                {% endwith %}
+            {% endif %}
+
+
+            <!-- Controlling Body -->
+            {% with facet_name='controlling_body' facet_label='Controlling Body' item_list=facets.fields.controlling_body selected_list=selected_facets.controlling_body %}
+                {% include 'partials/search_filter.html' %}
+            {% endwith %}
+
+
+            <!-- Sponsor -->
+            {% with facet_name='sponsorships' facet_label='Sponsor' item_list=facets.fields.sponsorships selected_list=selected_facets.sponsorships %}
+                {% include 'partials/search_filter.html' %}
+            {% endwith %}
+
+
+            <!-- Legislative Session -->
+            {% if facets.fields.legislative_session %}
+                <!-- only show leg sesh filter pane if there is more than one leg sesh to select from -->
+                {% if facets.fields.legislative_session|length > 1 %}
+
+                    {% with facet_name='legislative_session' facet_label='Legislative Session' item_list=facets.fields.legislative_session selected_list=selected_facets.legislative_session %}
+                        {% include 'partials/search_filter.html' %}
+                    {% endwith %}
+
+                {% endif %}
+            {% endif %}
+
+
+
+            <div class="divider"></div>
+        </div>
+
+        <div class="col-sm-8 order-nav">
+
+            <nav class="nav nav-inline order-nav">
+
+                Order by:
+
+                {% with sort_name='date' order_name='desc' %}
+                    {% include 'partials/order_by_filter.html' %}
+                {% endwith %}
+
+                {% with sort_name='title' order_name='asc' %}
+                    {% include 'partials/order_by_filter.html' %}
+                {% endwith %}
+
+                <!-- The templating logic is different for Relevance sort. The Relevance sort does not require a direction, and it should be bolded by default after submitting a query.-->
+                {% if 'sort_by=relevance' in request.get_full_path or 'order_by=' not in request.get_full_path and 'q=' in request.get_full_path %}
+                    <strong><a class="nav-link assort" href="{% search_with_querystring request sort_by='relevance' %}" data='sort_by=relevance'>
+                        Relevance
+                    </a></strong>
+                {% else %}
+                    <a class="sort-by nav-link" href="{% search_with_querystring request sort_by='relevance' %}" data='sort_by=relevance'>
+                        Relevance
+                    </a>
+                {% endif %}
+
+                {% if 'sort_by' in request.get_full_path %}
+                    <a href ="#" class="remove-order-value btn btn-sm btn-primary hidden-xs"
+                        {% if 'sort_by=date' in request.get_full_path %}
+                            data='sort_by=date'
+                        {% elif 'sort_by=title' in request.get_full_path%}
+                            data='sort_by=title'
+                        {% elif 'sort_by=relevance' in request.get_full_path%}
+                            data='sort_by=relevance'
+                        {% endif %}
+                        ><i class="fa fa-times"></i>
+                        Remove
+                    </a>
+
+                    <a href ="#" class="remove-order-value btn btn-sm btn-primary visible-xs"
+                        {% if 'sort_by=date' in request.get_full_path %}
+                            data='sort_by=date'
+                        {% elif 'sort_by=title' in request.get_full_path%}
+                            data='sort_by=title'
+                        {% elif 'sort_by=relevance' in request.get_full_path%}
+                            data='sort_by=relevance'
+                        {% endif %}
+                        ><i class="fa fa-times"></i>
+                    </a>
+                {% endif %}
+
+            </nav>
+
+            <hr>
+
+            {% if query or selected_facets %}
+            <h3 class="modal-links">
+
+                {% include 'partials/search_results_header.html' %}
+
+                <small>
+                {% if USING_NOTIFICATIONS %}
+                    {% if user_subscribed %}
+                    <a href="#" class="removeSubscription" data-toggle="tooltip" data-placement="top" data-html="true" title="You are subscribed to searches for {{request.GET.q}}!<br> Visit your accounts page to unsubscribe.">
+                        <i class="fa fa-envelope fa-fw" aria-hidden="true"></i>
+                    </a>
+                    {% else %}
+
+                        <!-- Monstrous code for using modal partials with three different RSS links -->
+                        {% if query and selected_facets %}
+
+                            {% with link_id='searchSubscribe' modal_id='Search' custom_text='searches for '|add:request.GET.q href='#' RSS_href=selected_facets.items|create_facet_string:request.GET.q RSS_for='RSS feed' %}
+                                {% include 'partials/subscription_modal.html' %}
+                            {% endwith %}
+
+                        {% elif selected_facets %}
+
+                            {% with link_id='searchSubscribe' modal_id='Search' custom_text='filters for '|add:'your filtered search' href='#' RSS_href=selected_facets.items|create_facet_string RSS_for='RSS feed' %}
+                                {% include 'partials/subscription_modal.html' %}
+                            {% endwith %}
+
+                        {% else %}
+
+                            {% with link_id='searchSubscribe' modal_id='Search' custom_text='searches for '|add:request.GET.q href='#' RSS_href='/search/rss/?q='|add:request.GET.q RSS_for='RSS feed' %}
+                                {% include 'partials/subscription_modal.html' %}
+                            {% endwith %}
+
+                        {% endif %}
+
+
+                    {% endif %}
+                {% else %}
+
+                    {% if query and selected_facets %}
+                        <a href="/search/rss/?q={{request.GET.q}}{% for key, values in selected_facets.items %}{% for value in values %}&selected_facets={{key}}:{{value}}{% endfor %}{% endfor %}" title="RSS feed">
+                    {% elif selected_facets %}
+                        <a href="/search/rss/?{% for key, values in selected_facets.items %}{% for value in values %}&selected_facets={{key}}:{{value}}{% endfor %}{% endfor %}" title="RSS feed">
+                    {% else %}
+                        <a href="/search/rss/?q={{request.GET.q}}" title="RSS feed">
+                    {% endif %}
+
+                    <i class="fa fa-rss-square" aria-hidden="true"></i></a>
+
+                {% endif %}
+                </small>
+            </h3>
+            <div class='row'>
+                <div class='col-sm-8' id='search_message'></div>
+            </div>
+            {% endif %}
+
+
+
+        {% for result in page.object_list %}
+
+            <!-- Legislation result -->
+
+            {% with r=result %}
+                {% include 'partials/search_result.html' %}
+            {% endwith %}
+
+
+            {% include 'partials/tags.html' %}
+
+
+        {% empty %}
+            {% include 'partials/empty_search_message.html' %}
+        {% endfor %}
+        </div>
+    </div>
+
+    {% if page.has_previous or page.has_next %}
+        <div class="row">
+            <div class="col-md-8 col-md-offset-4">
+                <nav>
+                    <ul class="pagination">
+                        {% if page.has_previous %}
+                            <li>
+                                <a href="?{{ q_filters }}&amp;page={{ page.previous_page_number }}" aria-label="Previous"><span aria-hidden="true">&laquo; Previous</span></a>
+                            </li>
+                        {% else %}
+                            <li class="disabled">
+                                <a href="#" aria-label="Previous"><span aria-hidden="true">&laquo; Previous</span></a>
+                            </li>
+                        {% endif %}
+
+                        {% if page.has_next %}
+                            <li>
+                                <a href="?{{ q_filters }}&amp;page={{ page.next_page_number }}" aria-label="Next"><span aria-hidden="true">Next &raquo;</span></a>
+                            </li>
+                        {% else %}
+                            <li class="disabled">
+                                <a href="#" aria-label="Next"><span aria-hidden="true">Next &raquo;</span></a>
+                            </li>
+                        {% endif %}
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    {% endif %}
+
+{% endblock %}
 
 {% block extra_js %}
   {{ block.super }}
@@ -11,5 +284,4 @@
   <script>
     autocompleteSearchBar('#autocomplete-search');
   </script>
-
 {% endblock %}

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -177,3 +177,9 @@ def get_highlighted_attachment_text(context, ocd_id):
     highlight = ExactHighlighter(context['query'])
     
     return highlight.highlight(attachment_text)
+
+@register.filter
+def matches_query(tag, request):
+    if request.GET.get('q'):
+        return tag.lower() == request.GET.get('q').lower()
+    return False


### PR DESCRIPTION
## Overview

This PR:

* Executes text search on autocomplete select (#458)
* Adds result type filter to result page (#459)
* Highlights tags matching query (#461)

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

![Screen Shot 2019-07-03 at 12 44 34 PM](https://user-images.githubusercontent.com/12176173/60613351-55b09c80-9d90-11e9-9bea-903571d9a9e0.png)
_Result type filter and highlighted topic._

### Notes

There are some tradeoffs to the way I implemented topic-only search.

The current implementation will perform case-insensitive search on the topics, but it will also include topics that only contain the term, e.g., "bus" matches "BUS" but it also matches "BUS IMPROVEMENTS". 

We could also search on `topics_exact`, however the search becomes case sensitive. I think we could get around this by defining a custom string field type that lowercases things before comparing them in the Solr index, then searching on `topics_exact`, but I want to check with Shelly and Omar about case sensitivity before we go that more involved route.

## Testing Instructions

* Refresh your local subject GUIDs: `python manage.py refresh_guid`
* Run the app: `python manage.py runserver`
* Search "Metro Green Line" and click the autosuggested topic. Confirm that a text search is run.
* On the results page, confirm that the "Metro Green Line" tag is highlighted in relevant results. Take note of the total number of results
* On the results page, click "Keyword only" and confirm that results tagged "Metro Green Line" do not appear in the search. Take note of the number of keyword results.
* On the results page, click "Topic only" and confirm that only results tagged "Metro Green Line" appear in the search. Take note of the number of topic results.
* Confirm that the number of keyword results plus the number of topic results equals the number of total results.
