### PR TITLE
Adding 2019 legislative session

### DIFF
--- a/councilmatic/settings_jurisdiction.py
+++ b/councilmatic/settings_jurisdiction.py
@@ -7,7 +7,7 @@
 OCD_CITY_COUNCIL_ID = 'ocd-organization/42e23f04-de78-436a-bec5-ab240c1b977c'
 CITY_COUNCIL_NAME = 'Metro'
 OCD_JURISDICTION_IDS = ['ocd-jurisdiction/country:us/state:ca/county:los_angeles/transit_authority']
-LEGISLATIVE_SESSIONS = ['2014', '2015', '2016', '2017', '2018'] # the last one in this list should be the current legislative session
+LEGISLATIVE_SESSIONS = ['2014', '2015', '2016', '2017', '2018', '2019'] # the last one in this list should be the current legislative session
 CITY_NAME = 'Metro'
 CITY_NAME_SHORT = 'Metro'
 


### PR DESCRIPTION
## Overview

This PR adds in the 2019 legislative session.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

We added it into the scrapers, but not the Councilmatic instance. https://github.com/opencivicdata/scrapers-us-municipal/commit/f70bf88c0bbaac9bebf77a9065c1d89b51c2ba1d

This should fix the errors that appeared this weekend.


## Testing Instructions

n/a

Handles #XXX
