### PR TITLE
Update API path, handle updated SubjectGuid

### DIFF
--- a/lametro/management/commands/refresh_guid.py
+++ b/lametro/management/commands/refresh_guid.py
@@ -49,4 +49,4 @@ class Command(BaseCommand):
 
         self.stdout.write('Created {0} new topics'.format(total_created))
         self.stdout.write('Updated {0} existing topics'.format(total_updated))
-        self.stdout.write("No-op'ed {0} topics".format(total_updated))
+        self.stdout.write('No-op {0} topics'.format(total_noop))

--- a/lametro/management/commands/refresh_guid.py
+++ b/lametro/management/commands/refresh_guid.py
@@ -1,5 +1,7 @@
 from django.core.management.base import BaseCommand
 from django.conf import settings
+from django.db.utils import IntegrityError
+
 from legistar.bills import LegistarAPIBillScraper
 from lametro.models import SubjectGuid, Subject
 
@@ -8,7 +10,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
 
         scraper = LegistarAPIBillScraper()
-        scraper.BASE_URL = 'https://webapi.legistar.com/v1/metrotest'
+        scraper.BASE_URL = 'https://webapi.legistar.com/v1/metro'
         scraper.retry_attempts = 0
         scraper.requests_per_minute = 0
 
@@ -21,12 +23,30 @@ class Command(BaseCommand):
         self.stdout.write('Removed {0} stale topics'.format(deleted))
 
         total_created = 0
-        for topic in all_topics:
-            subject, created = SubjectGuid.objects.get_or_create(
-                name=topic['IndexName'],
-                guid=topic['api_metadata']
-            )
-            if created:
-                total_created += 1
+        total_updated = 0
+        total_noop = 0
 
-        self.stdout.write('{0} topics created'.format(total_created))
+        for topic in all_topics:
+            try:
+                subject, created = SubjectGuid.objects.get_or_create(
+                    name=topic['IndexName'],
+                    guid=topic['api_metadata']
+                )
+            except IntegrityError as e:
+                # This exception will be raised if get_or_create tries to create
+                # a SubjectGuid with a name that already exists. The Legistar
+                # API should not contain duplicates, i.e., the GUID has changed.
+                # Update the GUID on the existing topic.
+                subject = SubjectGuid.objects.get(name=topic['IndexName'])
+                subject.guid = topic['api_metadata']
+                subject.save()
+                total_updated += 1
+            else:
+                if created:
+                    total_created += 1
+                else:
+                    total_noop += 1
+
+        self.stdout.write('Created {0} new topics'.format(total_created))
+        self.stdout.write('Updated {0} existing topics'.format(total_updated))
+        self.stdout.write("No-op'ed {0} topics".format(total_updated))


### PR DESCRIPTION
## Overview

This PR:

- Points the app at the production Legistar API. Closes #478.
- Handles updates to subject GUIDs. Per Metro, all matter indexes were recreated in the go-live, resulting in instances where a subject's GUID changed, breaking our sync process. The GUIDs should be stable moving forward, however in an abundance of caution, this PR adds logic to update the GUID of existing SubjectGuids, if this issue recurs. This will also handle the current exceptions, without our having to do database surgery. Closes #479.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Open a Django shell: `python manage.py shell`.
 * Remove any existing SubjectGuids and create a dummy SubjectGuid: `from uuid import uuid4; from lametro.models import SubjectGuid; SubjectGuid.objects.all().delete(); SubjectGuid.objects.create(name='SR-134', guid=uuid4())`
 * Exit the shell: `exit()`
 * Run the management command and confirm that the log output indicates one topic was updated: `python manage.py refresh_guid`
