### PR TITLE
Remove recent activity from committee page, related to #342

### DIFF
--- a/lametro/templates/lametro/committee.html
+++ b/lametro/templates/lametro/committee.html
@@ -25,7 +25,6 @@
     <div class="row-fluid">
         <div class="col-sm-12">
             {% if committee.recent_events %}
-
                 <h4>
                     <i class='fa fa-fw fa-calendar-o'></i> Committee {{ CITY_VOCAB.EVENTS }}
                     <a href="events/rss/" title="RSS feed for Committe Events by {{committee.name}}"><i class="fa fa-rss-square" aria-hidden="true"></i></a>
@@ -167,16 +166,6 @@
             }
         });
 
-        function collapseActivity(){
-            $(".activity-row:gt(4)").hide();
-            $("#more-actions").show();
-            $("#fewer-actions").hide();
-        }
-        function expandActivity(){
-            $(".activity-row:gt(4)").show();
-            $("#more-actions").hide();
-            $("#fewer-actions").show();
-        }
         function collapseEvents(){
             $(".event-listing:gt(4)").hide();
             $("#more-events").show();
@@ -188,17 +177,8 @@
             $("#fewer-events").show();
         }
 
-        collapseActivity();
         collapseEvents();
 
-        $("#more-actions").click(function() {
-            expandActivity();
-            return false;
-        });
-        $("#fewer-actions").click(function() {
-            collapseActivity();
-            return false;
-        });
         $("#more-events").click(function() {
             expandEvents();
             return false;

--- a/lametro/templates/lametro/committee.html
+++ b/lametro/templates/lametro/committee.html
@@ -23,62 +23,7 @@
     </div>
 
     <div class="row-fluid">
-        {% if committee.recent_activity %}
-        <!-- Recent activity -->
-        <div class="col-sm-7">
-            <h4><i class='fa fa-fw fa-list-ul'></i> Recent Activity
-                <a href="actions/rss/" title="RSS feed for Recent Activity by {{committee.name}}" target="_blank"><i class="fa fa-rss-square" aria-hidden="true"></i></a>
-            </h4>
-            <div class="table-responsive">
-                <table class='table' id='committee-actions'>
-                    <thead>
-                        <tr>
-                            <th>Action</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for action in committee.recent_activity %}
-                            <tr class="activity-row">
-                                <td class='nowrap'>
-                                    <p class="text-muted small no-pad-bottom">
-                                        {{action.date|date:'n/d/Y'}}
-                                    </p>
-                                    <p class="small no-pad-bottom">
-                                        <span class='text-{{action.label}}'>{{action.description | remove_action_subj}}</span>
-                                    </p>
-                                </td>
-                                <td>
-                                    <p class="small no-pad-bottom">
-                                        <a href="/board-report/{{action.bill.slug}}/">{{action.bill.friendly_name}}</a>
-                                    </p>
-                                    <p class="small no-pad-bottom">
-                                        {{action.bill.description | short_blurb}}
-                                    </p>
-                                </td>
-                            </tr>
-                        {% endfor %}
-
-                        {% if committee.recent_activity|length > 4  %}
-                            <tr>
-                                <td colspan="3" align="center">
-                                    <a href="" id="more-actions"><i class="fa fa-fw fa-chevron-down"></i>Show more</a>
-                                    <a href="" id="fewer-actions"><i class="fa fa-fw fa-chevron-up"></i>Show fewer</a>
-                                </td>
-                            </tr>
-                        {% endif %}
-
-                    </tbody>
-                </table>
-            </div>
-        </div>
-
-        <!-- Recent events -->
-        <div class="col-sm-5">
-        {% else %}
-        <!-- If no committee activity, remove `committee-actions` table entirely, and expand the recent events column to 100%.  -->
         <div class="col-sm-12">
-        {% endif %}
             {% if committee.recent_events %}
 
                 <h4>
@@ -94,7 +39,6 @@
                 <a href="" id="more-events"><i class="fa fa-fw fa-chevron-down"></i>Show more</a>
                 <a href="" id="fewer-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer</a>
             {% endif %}
-
         </div>
     </div>
 


### PR DESCRIPTION
## Overview

This PR removes the recent activity feed from committee pages, until we can address the data issue outlined in https://github.com/datamade/la-metro-councilmatic/issues/342#issuecomment-436302765.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

![Screen Shot 2019-08-29 at 3 31 52 PM (2)](https://user-images.githubusercontent.com/12176173/63974292-2fe30380-ca72-11e9-82e7-b284a6a5849f.png)

### Notes

This PR should be reverted once we sort out how to import recent activity correctly.

## Testing Instructions

 * Run the application
 * Navigate to each committee page and confirm that:
    * The page does not have a recent activity feed
    * The markup renders correctly

Related to #342 