### PR TITLE
Use <object> to display PDFs

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -26,6 +26,9 @@ hooks:
       runas: root
 
 branch_config:
+  hec/feature/render-pdf-with-object:
+    deploymentGroupName: staging
+
   master:
     deploymentGroupName: staging
 

--- a/lametro/templates/lametro/legislation.html
+++ b/lametro/templates/lametro/legislation.html
@@ -35,7 +35,7 @@
             </div>
         </div>
 
-        <div class="col-sm-8 no-pad-mobile">
+        <div class="col-sm-8 no-pad-mobile" id="pdf-container">
 
             {% if legislation.board_report %}
 	    {% with board_report=legislation.board_report %}
@@ -55,15 +55,14 @@
                     </p>
                 {% endif %}
 
-                <iframe
+                <!-- Width is set programmatically. --->
+                <object
                     id="pdf-embed-agenda"
                     class="pdf-viewer hidden-xs"
-                    frameborder="0"
-                    seamless="true"
-                    width="100%"
-                    height="600px"
-                    src="/pdfviewer/?{{board_report.url|full_text_doc_url}}">
-                </iframe>
+                    type="application/pdf"
+                    data="{{board_report.url|full_text_doc_url}}"
+                    height="600px">
+                </object>
 
                 <div class="divider"></div>
 	    {% endwith %}
@@ -277,10 +276,10 @@
         });
 
         if (window.screen.width > 768){
-            $("#pdf-embed").attr("src", "/pdfviewer/?{{legislation.url|full_text_doc_url}}");
+            $('#pdf-embed-agenda').width($('#pdf-container').width());
         }
         else{
-            $('#pdf-embed').hide()
+            $('#pdf-embed-agenda').hide()
             $('#pdf-download-link').html("<i class='fa fa-fw fa-external-link'></i> View PDF")
         }
 

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -59,9 +59,7 @@ def prepare_title(full_text):
 @register.filter
 def full_text_doc_url(url):
     query = {'document_url': url, 'filename': 'agenda'}
-    pic_query = {'file': PIC_BASE_URL + '?' + urllib.parse.urlencode(query)}
-
-    return urllib.parse.urlencode(pic_query)
+    return PIC_BASE_URL + '?' + urllib.parse.urlencode(query)
 
 '''
 This filter converts the post title into a prose-style format with nomination info,


### PR DESCRIPTION
## Overview

This PR replaces `pdf.js` with an `<object>` element to render board report PDFs, in an attempt to make embedded hyperlinks clickable. This seems to work, even on old versions of IE.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

![Screen Shot 2019-09-09 at 11 17 26 AM (2)](https://user-images.githubusercontent.com/12176173/64548022-6ed74b80-d2f3-11e9-8f70-7eda50c6bbbf.png)

### Notes

Contemporary FireFox on ~Windows~ all OSes seems to have some issues, namely that the PDF does not display. However, I cannot replicate this issue (which I observed in BrowserStack) on my local version of Firefox Quantum (versions 68 & 69, on OS X Mojave).

## Testing Instructions

tk tk tk.

Related to #294.