### PR TITLE
Changing text on search filter buttons

### DIFF
--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -51,8 +51,8 @@
             <p id="result-type-filter">
                 Result type:
                 <a class="btn btn-primary btn-sm{% if 'result_type' not in request.get_full_path or 'result_type=all' in request.get_full_path %} active{% endif %}" href="{% search_with_querystring request q=request.GET.q|remove_question result_type='all' %}">All</a>
-                <a class="btn btn-primary btn-sm{% if 'result_type=keyword' in request.get_full_path  %} active{% endif %}" href="{% search_with_querystring request result_type='keyword' %}">Keyword only</a>
-                <a class="btn btn-primary btn-sm{% if 'result_type=topic' in request.get_full_path %} active{% endif %}" href="{% search_with_querystring request result_type='topic' %}">Topic only</a>
+                <a class="btn btn-primary btn-sm{% if 'result_type=keyword' in request.get_full_path  %} active{% endif %}" href="{% search_with_querystring request result_type='keyword' %}">Text Search</a>
+                <a class="btn btn-primary btn-sm{% if 'result_type=topic' in request.get_full_path %} active{% endif %}" href="{% search_with_querystring request result_type='topic' %}">Tag Search</a>
             </p>
 
             {% if selected_facets %}


### PR DESCRIPTION
## Overview

Changes the text of search buttons as requested.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="1265" alt="Screen Shot 2019-09-11 at 2 45 31 PM" src="https://user-images.githubusercontent.com/6961258/64729543-f7e0b500-d4a2-11e9-85bd-023c81b722d9.png">

## Testing Instructions

Search for a term, then confirm that "Text Search" is for keywords and "Tag Search" is for topics.

Handles #472
