### PR TITLE
Adding tags to sidebar on legislation page

### DIFF
--- a/lametro/templates/lametro/legislation.html
+++ b/lametro/templates/lametro/legislation.html
@@ -146,15 +146,15 @@
                         <thead>
                             <tr>
                                 <th>Board Report</th>
-                                <th class='no-wrap'>Last action</th>                            
+                                <th class='no-wrap'>Last action</th>
                             </tr>
                         </thead>
                         <tbody>
                             {% for bill in related_bills %}
                                 <tr>
                                     <td class='text-muted small'>
-                                        <a href="{% url 'lametro:bill_detail' bill.slug %}">{{ bill.identifier}}</a> 
-                                        
+                                        <a href="{% url 'lametro:bill_detail' bill.slug %}">{{ bill.identifier}}</a>
+
                                         {% if bill.ocr_full_text|prepare_title %}
                                             - {{ bill.ocr_full_text|prepare_title }}
                                         {% endif %}
@@ -168,6 +168,19 @@
                     </table>
                 </div>
                 <div class="divider"></div>
+            {% endif %}
+
+            {% if topics %}
+              <h3 class="no-pad-bottom"><i class="fas fa-tag" aria-hidden="true"></i> Tags</h3>
+              {% for topic in topics %}
+                {% with "topics_exact:"|add:tag as tag_facet %}
+                  <li>
+                      <a href="{% search_with_querystring request selected_facets=tag_facet %}" target="blank">
+                        {{ topic.subject }}
+                      </a>
+                  </li>
+                {% endwith %}
+              {% endfor %}
             {% endif %}
         </div>
 

--- a/lametro/templates/lametro/legislation.html
+++ b/lametro/templates/lametro/legislation.html
@@ -137,9 +137,8 @@
                 <div class="divider"></div>
             {% endif %}
 
-            <br>
-
             {% if related_bills %}
+            <br>
                 <h3 class="no-pad-bottom"><i class="fa fa-file-text" aria-hidden="true"></i> Related Board Reports</h3>
                 <div class="table-responsive">
                     <table class='table table-responsive' id='committee-actions'>
@@ -170,17 +169,20 @@
                 <div class="divider"></div>
             {% endif %}
 
-            {% if topics %}
-              <h3 class="no-pad-bottom"><i class="fas fa-tag" aria-hidden="true"></i> Tags</h3>
-              {% for topic in topics %}
-                {% with "topics_exact:"|add:tag as tag_facet %}
-                  <li>
-                      <a href="{% search_with_querystring request selected_facets=tag_facet %}" target="blank">
-                        {{ topic.subject }}
-                      </a>
-                  </li>
-                {% endwith %}
-              {% endfor %}
+            {% if legislation.topics %}
+            <br>
+              <h3><i class="fa fa-tag" aria-hidden="true"></i> Tags</h3>
+              <ul>
+                {% for topic in legislation.topics %}
+                  {% with "topics_exact:"|add:topic as tag_facet %}
+                    <li>
+                        <a href="{% search_with_querystring request selected_facets=tag_facet %}" target="blank">
+                          {{ topic }}
+                        </a>
+                    </li>
+                  {% endwith %}
+                {% endfor %}
+              </ul>
             {% endif %}
         </div>
 


### PR DESCRIPTION
## Overview

This adds in a list of a report's tags to the detail page.

### Checklist

- [ ] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="643" alt="Screen Shot 2019-09-11 at 3 53 21 PM" src="https://user-images.githubusercontent.com/6961258/64734574-80178800-d4ac-11e9-8050-58af969ad2bb.png">

## Testing Instructions

- Search for a piece of legislation.
- Confirm that when you click on it, the tags displayed in the search result match those in the sidebar.
- Click on the tag links and confirm they open corresponding searches in a new tab.

Handles #XXX
