### PR TITLE
[WIP] Source autosuggestions from the /concepts endpoint

### DIFF
--- a/lametro/static/js/autocomplete.js
+++ b/lametro/static/js/autocomplete.js
@@ -17,7 +17,7 @@ var SmartLogic = {
     };
   },
   buildServiceUrl: function(query) {
-    return 'https://cloud.smartlogic.com/svc/0ef5d755-1f43-4a7e-8b06-7591bed8d453/ses/CombinedModel/hints/' + query + '.json?FILTER=AT=System:%20Legistar';
+    return 'https://cloud.smartlogic.com/svc/0ef5d755-1f43-4a7e-8b06-7591bed8d453/ses/CombinedModel/concepts/' + query + '.json?FILTER=AT=System:%20Legistar&stop_cm_after_stage=3&maxResultCount=10';
   }
 };
 
@@ -36,20 +36,23 @@ function autocompleteSearchBar(element) {
     paramName: '',
     transformResult: function(response) {
       var res = JSON.parse(response);
-      if (res.status_code == 500 || res.termHints.length < 1) {
+      if (res.status_code == 500 || res.terms.length < 1) {
         return {
           suggestions: ['No topics found']
         };
       } else {
         return {
-          suggestions: $.map(res.termHints, function(d) {
+          suggestions: $.map(res.terms, function(d) {
+              // TODO: If Metro prefers these results, refactor this to work
+              // with the /concepts result structure
               /* If the search term is an acronym, displays that as a part of the suggestion */
-              var nature = '';
-              if (d.values[0]['nature'] == 'NPT') {
-                nature = d.values[0]['value'];
-                nature = ' (' + nature + ')';
-              }
-              return {'value': d.name + nature, 'data': d.id};
+              //var nature = '';
+              //if (d.values[0]['nature'] == 'NPT') {
+              //  nature = d.values[0]['value'];
+              //  nature = ' (' + nature + ')';
+              //}
+              //return {'value': d.name + nature, 'data': d.id};
+              return {'value': d.term.name, 'data': d.term.id};
             }
           )
         };


### PR DESCRIPTION
## Overview

Per Metro, some suggestions from the `/hints` endpoint don't make a lot of sense, especially for noisy (non-specific) terms, e.g., results for "red line" do not include "Metro Red Line". While we can introduce filters on class to refine results, there isn't much we can do to alter how this endpoint determines relevance, i.e., prioritizing certain results.

Steve suggested trying the `/concepts` endpoint. Per the docs,

> The “concepts” command will return terms within the model that are related to the supplied query term. 

Steve said this is generally more useful for free text searches.

This PR queries `/concepts` for suggested terms.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

I want to get Metro's reaction to the quality of results before I spend a lot of time on this. The new endpoint returns results in a slightly different format than `/hints`, so the preferred / alternate term logic is broken. If Metro prefers this strategy, we should go in and repair it before merging.

## Testing Instructions

 * tk tk tk.

Handles #494 .