### PR TITLE
Add clarifying search instructions

### DIFF
--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -33,8 +33,8 @@ h1, .h1 {
 #section-photo {
     background-image:
         linear-gradient(
-          rgba(0, 0, 0, 0.6),
-          rgba(270, 270, 270, 0.3)
+          rgba(0, 0, 0, 0.9),
+          rgba(270, 270, 270, 0.6)
         ),
         url('../images/la-metro-regional-rail-map-copy.gif');
     background-size: cover;
@@ -171,6 +171,10 @@ div#google_translate_element {
 
 .label-failed, .label-withdrawn {
     background-color: #E00700;
+}
+
+#search-help {
+  font-size: 16px;
 }
 
 /* Styles for order by options on search page */

--- a/lametro/static/js/autocomplete.js
+++ b/lametro/static/js/autocomplete.js
@@ -36,9 +36,10 @@ function autocompleteSearchBar(element) {
     paramName: '',
     transformResult: function(response) {
       var res = JSON.parse(response);
+      var noneFoundText = "No suggestions found. Press enter to perform a keyword search."
       if (res.status_code == 500 || res.termHints.length < 1) {
         return {
-          suggestions: ['No topics found']
+          suggestions: [noneFoundText]
         };
       } else {
         return {

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -7,12 +7,13 @@
             <div class='col-sm-10 col-sm-offset-1'>
                 <span class="hidden-xs hidden-sm"><br/><br/></span>
                     <h1 class="home-header">Los Angeles County Metropolitan Transportation Authority</h1>
-                <span class="hidden-xs hidden-sm"><br/></span>
                 <p class="h3">
                     <span class="text-bg">Search Metro Board Reports (2015 – present)</span>
                 </p>
-                <p style="color: #ffffff;font-weight: bold;">
-                  Press enter to perform a keyword search, or select from suggested topics as they appear.
+                <p>
+                  <span class="text-bg">
+                    Press enter to perform a keyword search, or select from suggested topics as they appear.
+                  </span>
                 </p>
                 <form class="search form-search=" action="/search/" method="GET">
                     <div class="input-group site-intro-search">

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -11,6 +11,9 @@
                 <p class="h3">
                     <span class="text-bg">Search Metro Board Reports (2015 – present)</span>
                 </p>
+                <p style="color: #ffffff;font-weight: bold;">
+                  Press enter to perform a keyword search, or select from suggested topics as they appear.
+                </p>
                 <form class="search form-search=" action="/search/" method="GET">
                     <div class="input-group site-intro-search">
                         <input name="q"  id="search-bar" type="text" class="input-lg form-control form-lg" placeholder="{{ SEARCH_PLACEHOLDER_TEXT }}">

--- a/lametro/templates/partials/search_header.html
+++ b/lametro/templates/partials/search_header.html
@@ -1,3 +1,8 @@
 <p class="h4">
     Search Metro Board Reports
 </p>
+<p>
+  <small>
+    Press enter to perform a keyword search, or select from suggested topics as they appear.
+  </small>
+</p>

--- a/lametro/templates/partials/search_header.html
+++ b/lametro/templates/partials/search_header.html
@@ -1,8 +1,6 @@
 <p class="h4">
     Search Metro Board Reports
 </p>
-<p>
-  <small>
+<p id="search-help">
     Press enter to perform a keyword search, or select from suggested topics as they appear.
-  </small>
 </p>


### PR DESCRIPTION
## Overview

Changes the language of the autocomplete feature.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="1274" alt="Screen Shot 2019-09-19 at 11 33 35 AM" src="https://user-images.githubusercontent.com/6961258/65263387-2a596600-dad2-11e9-9da7-da0aa4af079a.png">

## Testing Instructions

- Go to the homepage. 
- Confirm the instructions are above the search bar and are legible.
- Search for something nonsensical, and confirm the language in the suggestions box is correct.
- Execute a search.
- Confirm the instructions appear above the search bar on the search results page.

Handles #493 
