### PR TITLE
Sort topics in search sidebar, in search results, and on board report page

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -136,7 +136,7 @@ class LAMetroBill(Bill):
 
     @property
     def topics(self):
-        return [s.subject for s in self.subjects.all()]
+        return sorted(s.subject for s in self.subjects.all())
 
 
 class LAMetroPost(Post):

--- a/lametro/templates/partials/search_filter.html
+++ b/lametro/templates/partials/search_filter.html
@@ -38,7 +38,7 @@
                     </li>
                     {% endif %}
                 {% endfor %}
-                {% for name, count in facets.fields.topics %}
+                {% for name, count in facets.fields.topics|sort_by_index:0 %}
                     {% if count %}
                     <li class="small">
                         {% if name not in selected_list %}

--- a/lametro/templates/partials/search_filter.html
+++ b/lametro/templates/partials/search_filter.html
@@ -33,10 +33,18 @@
                             <a href ="#" class="remove-filter-value" data="{{facet_name}}_exact:{{name}}">
                                <i class="fa fa-times"></i>
                             </a>
-                        {% else %}
-                            <a href="#" class="filter-value" data="{{facet_name}}_exact:{{name}}" title="{{ name }}">{{ name | short_topic_name }}</a>
+                            <span class="badge badge-facet pull-right">{{ count }}</span>
                         {% endif %}
-                        <span class="badge badge-facet pull-right">{{ count }}</span>
+                    </li>
+                    {% endif %}
+                {% endfor %}
+                {% for name, count in facets.fields.topics %}
+                    {% if count %}
+                    <li class="small">
+                        {% if name not in selected_list %}
+                            <a href="#" class="filter-value" data="{{facet_name}}_exact:{{name}}" title="{{ name }}">{{ name | short_topic_name }}</a>
+                            <span class="badge badge-facet pull-right">{{ count }}</span>
+                        {% endif %}
                     </li>
                     {% endif %}
                 {% endfor %}

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -742,7 +742,7 @@ class LAMetroCouncilmaticFacetedSearchView(CouncilmaticFacetedSearchView):
         sqs = SearchQuerySet().facet('bill_type', sort='index')\
                               .facet('sponsorships', sort='index')\
                               .facet('inferred_status')\
-                              .facet('topics', sort='index')\
+                              .facet('topics')\
                               .facet('legislative_session', sort='index')\
                               .highlight(**{'hl.fl': 'text,attachment_text'})
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -742,7 +742,7 @@ class LAMetroCouncilmaticFacetedSearchView(CouncilmaticFacetedSearchView):
         sqs = SearchQuerySet().facet('bill_type', sort='index')\
                               .facet('sponsorships', sort='index')\
                               .facet('inferred_status')\
-                              .facet('topics')\
+                              .facet('topics', sort='index')\
                               .facet('legislative_session', sort='index')\
                               .highlight(**{'hl.fl': 'text,attachment_text'})
 


### PR DESCRIPTION
## Overview

This PR:

- Sorts the `topics` property by default to sort topics beneath search results and on board report pages alphabetically.
- Adds a `sort_by_index` template filter to sort lists of iterables by index or key and uses it to sort topics in the search sidebar.
- Updates the topic facet template to list selected facets first.

Handles #500, #501, and #503.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

N/A

### Notes

N/A

## Testing Instructions

* Run the app as described in the README – being sure to load in a bit of data and populate the Solr index.
* Run a query returning results, e.g., train. On the search results page, confirm that topics are listed alphabetically below search results.
* Open the Topics filter and confirm that topics are listed alphabetically. Select a topic and confirm that selected topics are listed first, followed by the remaining topics, listed alphabetically.
* Click a search result. On the board report page, confirm the topics are listed alphabetically.
