### PR TITLE
Show at most 10 topics in search results

### DIFF
--- a/lametro/templates/partials/search_filter.html
+++ b/lametro/templates/partials/search_filter.html
@@ -23,7 +23,6 @@
         </div>
         <div class="panel-body {% if facet_name in selected_facets %}panel-show{% endif %} collapse" id="filter-{{facet_name}}">
             <ul class="search-facet-list">
-
             {% if facet_name == 'topics' %}
                 {% for name, count in facets.fields.topics %}
                     {% if count %}

--- a/lametro/templates/partials/search_filter.html
+++ b/lametro/templates/partials/search_filter.html
@@ -26,25 +26,25 @@
             {% if facet_name == 'topics' %}
                 {% for name, count in facets.fields.topics %}
                     {% if count %}
-                    <li class="small">
                         {% if name in selected_list %}
-                            <a href="#" class="filter-value" data="{{facet_name}}_exact:{{name}}" title="{{ name }}"><strong>{{ name | short_topic_name }}</strong></a>
-                            <a href ="#" class="remove-filter-value" data="{{facet_name}}_exact:{{name}}">
-                               <i class="fa fa-times"></i>
-                            </a>
-                            <span class="badge badge-facet pull-right">{{ count }}</span>
+                            <li class="small">
+                                <a href="#" class="filter-value" data="{{facet_name}}_exact:{{name}}" title="{{ name }}"><strong>{{ name | short_topic_name }}</strong></a>
+                                <a href ="#" class="remove-filter-value" data="{{facet_name}}_exact:{{name}}">
+                                   <i class="fa fa-times"></i>
+                                </a>
+                                <span class="badge badge-facet pull-right">{{ count }}</span>
+                            </li>
                         {% endif %}
-                    </li>
                     {% endif %}
                 {% endfor %}
                 {% for name, count in facets.fields.topics|sort_by_index:0 %}
                     {% if count %}
-                    <li class="small">
                         {% if name not in selected_list %}
-                            <a href="#" class="filter-value" data="{{facet_name}}_exact:{{name}}" title="{{ name }}">{{ name | short_topic_name }}</a>
-                            <span class="badge badge-facet pull-right">{{ count }}</span>
+                            <li class="small">
+                                <a href="#" class="filter-value" data="{{facet_name}}_exact:{{name}}" title="{{ name }}">{{ name | short_topic_name }}</a>
+                                <span class="badge badge-facet pull-right">{{ count }}</span>
+                            </li>
                         {% endif %}
-                    </li>
                     {% endif %}
                 {% endfor %}
             {% elif facet_name == 'sponsorships' %}

--- a/lametro/templates/partials/tags.html
+++ b/lametro/templates/partials/tags.html
@@ -17,13 +17,27 @@
     {% if result.object.topics %}
         <i class="fa fa-fw fa-tag"></i>
         {% hits_first result.object.topics selected_facets.topics as tags %}
-        {% for tag in tags %}
+        {% for tag in tags|slice:":4" %}
             {% with "topics_exact:"|add:tag as tag_facet %}
             <span class="badge{% if tag|matches_query:request or tag|matches_facet:selected_facets.topics %} badge-highlight{% else %} badge-muted{% endif %} pseudo-topic-tag">
                 <a href="{% search_with_querystring request selected_facets=tag_facet %}">{{tag}}</a>
             </span>&nbsp;
             {% endwith %}
         {% endfor %}
+        {% if tags|length > 5 %}
+            <a data-toggle="collapse" href="#collapse-{{ result.slug }}" aria-expanded="false" aria-controls="collapse-{{ result.slug }}">
+                More...
+            </a>
+            <div class="collapse" id="collapse-{{ result.slug }}">
+                {% for tag in tags|slice:"4:" %}
+                    {% with "topics_exact:"|add:tag as tag_facet %}
+                    <span class="badge{% if tag|matches_query:request or tag|matches_facet:selected_facets.topics %} badge-highlight{% else %} badge-muted{% endif %} pseudo-topic-tag">
+                        <a href="{% search_with_querystring request selected_facets=tag_facet %}">{{tag}}</a>
+                    </span>&nbsp;
+                    {% endwith %}
+                {% endfor %}
+            </div>
+        {% endif %}
         <br/>
     {% elif result.object.pseudo_topics %}
         <i class="fa fa-fw fa-tag"></i>
@@ -37,6 +51,5 @@
         {% endfor %}
         <br/>
     {% endif %}
-    </br>
     </div>
 </div>

--- a/lametro/templates/partials/tags.html
+++ b/lametro/templates/partials/tags.html
@@ -24,7 +24,7 @@
             </span>&nbsp;
             {% endwith %}
         {% endfor %}
-        {% if tags|length > 5 %}
+        {% if tags|length > 10 %}
             <small>
                 <a data-toggle="collapse" href="#collapse-{{ result.slug }}" aria-expanded="false" aria-controls="collapse-{{ result.slug }}">More&nbsp;topics...</a>
             </small>

--- a/lametro/templates/partials/tags.html
+++ b/lametro/templates/partials/tags.html
@@ -25,9 +25,9 @@
             {% endwith %}
         {% endfor %}
         {% if tags|length > 5 %}
-            <a data-toggle="collapse" href="#collapse-{{ result.slug }}" aria-expanded="false" aria-controls="collapse-{{ result.slug }}">
-                More&nbsp;tags...
-            </a>
+            <small>
+                <a data-toggle="collapse" href="#collapse-{{ result.slug }}" aria-expanded="false" aria-controls="collapse-{{ result.slug }}">More&nbsp;topics...</a>
+            </small>
             <div class="collapse" id="collapse-{{ result.slug }}">
                 {% for tag in tags|slice:"10:" %}
                     {% with "topics_exact:"|add:tag as tag_facet %}

--- a/lametro/templates/partials/tags.html
+++ b/lametro/templates/partials/tags.html
@@ -17,7 +17,7 @@
     {% if result.object.topics %}
         <i class="fa fa-fw fa-tag"></i>
         {% hits_first result.object.topics selected_facets.topics as tags %}
-        {% for tag in tags|slice:":4" %}
+        {% for tag in tags|slice:":10" %}
             {% with "topics_exact:"|add:tag as tag_facet %}
             <span class="badge{% if tag|matches_query:request or tag|matches_facet:selected_facets.topics %} badge-highlight{% else %} badge-muted{% endif %} pseudo-topic-tag">
                 <a href="{% search_with_querystring request selected_facets=tag_facet %}">{{tag}}</a>
@@ -26,10 +26,10 @@
         {% endfor %}
         {% if tags|length > 5 %}
             <a data-toggle="collapse" href="#collapse-{{ result.slug }}" aria-expanded="false" aria-controls="collapse-{{ result.slug }}">
-                More...
+                More&nbsp;tags...
             </a>
             <div class="collapse" id="collapse-{{ result.slug }}">
-                {% for tag in tags|slice:"4:" %}
+                {% for tag in tags|slice:"10:" %}
                     {% with "topics_exact:"|add:tag as tag_facet %}
                     <span class="badge{% if tag|matches_query:request or tag|matches_facet:selected_facets.topics %} badge-highlight{% else %} badge-muted{% endif %} pseudo-topic-tag">
                         <a href="{% search_with_querystring request selected_facets=tag_facet %}">{{tag}}</a>
@@ -38,7 +38,7 @@
                 {% endfor %}
             </div>
         {% endif %}
-        <br/>
+        <br /><br />
     {% elif result.object.pseudo_topics %}
         <i class="fa fa-fw fa-tag"></i>
         {% hits_first result.object.pseudo_topics selected_facets.topics as tags %}

--- a/lametro/templates/partials/tags.html
+++ b/lametro/templates/partials/tags.html
@@ -16,9 +16,10 @@
     <div class="col-xs-11">
     {% if result.object.topics %}
         <i class="fa fa-fw fa-tag"></i>
-        {% for tag in result.object.topics %}
+        {% hits_first result.object.topics selected_facets.topics as tags %}
+        {% for tag in tags %}
             {% with "topics_exact:"|add:tag as tag_facet %}
-            <span class="badge {% if tag|matches_query:request %}badge-highlight{% else %}badge-muted{% endif %} pseudo-topic-tag">
+            <span class="badge{% if tag|matches_query:request or tag|matches_facet:selected_facets.topics %} badge-highlight{% else %} badge-muted{% endif %} pseudo-topic-tag">
                 <a href="{% search_with_querystring request selected_facets=tag_facet %}">{{tag}}</a>
             </span>&nbsp;
             {% endwith %}
@@ -26,9 +27,10 @@
         <br/>
     {% elif result.object.pseudo_topics %}
         <i class="fa fa-fw fa-tag"></i>
-        {% for tag in result.object.pseudo_topics %}
+        {% hits_first result.object.pseudo_topics selected_facets.topics as tags %}
+        {% for tag in tags %}
             {% with "sponsorships_exact:"|add:tag as tag_facet %}
-            <span class="badge badge-muted pseudo-topic-tag">
+            <span class="badge{% if tag|matches_query:request or tag|matches_facet:selected_facets.topics %} badge-highlight{% else %} badge-muted{% endif %} pseudo-topic-tag">
                 <a href="{% search_with_querystring request selected_facets=tag_facet %}">{{ tag | committee_topic_only }}</a>
             </span>&nbsp;
             {% endwith %}

--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -50,7 +50,6 @@
                 {% with formatted_q=request.GET.q|remove_question %}
                     {% include 'partials/search_bar.html' %}
                 {% endwith %}
-            </div>
         </form>
     </div>
 
@@ -292,6 +291,6 @@
 
   <script>
     autocompleteSearchBar('#autocomplete-search');
-    $('#beta-info').tooltip({html: true, trigger: 'focus click', placement: 'right'})
+    $('#beta-info').tooltip({html: true, trigger: 'focus click', placement: 'right'});
   </script>
 {% endblock %}

--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -284,8 +284,6 @@
 
 {% block extra_js %}
   {{ block.super }}
-  <script src="{% static 'js/jquery-1.10.1.min.js' %}"></script>
-  <script src="{% static 'js/bootstrap.min.js' %}"></script>
   <script src="{% static 'js/jquery.autocomplete.js' %}"></script>
   <script src="{% static 'js/autocomplete.js' %}"></script>
 

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -212,7 +212,9 @@ def hits_first(context, topics, selected_topics):
     if selected_topics:
         terms += selected_topics
 
-    hits = list(set(topics).intersection(set(terms)))
-    topics = list(set(topics) - set(terms))
+    lower_terms = [t.lower() for t in terms]
+    lower_topics = [t.lower() for t in topics]
 
-    return sorted(hits) + sorted(topics)
+    hits = list(set(lower_topics).intersection(set(lower_terms)))
+
+    return sorted(t for t in topics if t.lower() in hits) + sorted(t for t in topics if t.lower() not in hits)

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -182,6 +182,12 @@ def matches_query(tag, request):
     return False
 
 @register.filter
+def matches_facet(tag, facet):
+    if facet:
+        return tag.lower() in [t.lower() for t in facet]
+    return False
+
+@register.filter
 def sort_by_index(array, index):
     '''
     Sort a list of tuples by an item in that tuple, e.g., sort a facet listing
@@ -194,3 +200,19 @@ def sort_by_index(array, index):
     https://docs.djangoproject.com/en/1.10/ref/templates/builtins/
     '''
     return sorted(array, key=lambda x: x[index])
+
+@register.simple_tag(takes_context=True)
+def hits_first(context, topics, selected_topics):
+    '''
+    Return array of topics, such that topics matching a selected facet or the
+    search term are returned first, followed by the remaining tags in ABC order.
+    '''
+    terms = [context['query']]
+
+    if selected_topics:
+        terms += selected_topics
+
+    hits = list(set(topics).intersection(set(terms)))
+    topics = list(set(topics) - set(terms))
+
+    return sorted(hits) + sorted(topics)

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -212,9 +212,9 @@ def hits_first(context, topics, selected_topics):
     if selected_topics:
         terms += selected_topics
 
-    lower_terms = [t.lower() for t in terms]
-    lower_topics = [t.lower() for t in topics]
+    lower_terms = set(t.lower() for t in terms)
+    lower_topics = set(t.lower() for t in topics)
 
-    hits = list(set(lower_topics).intersection(set(lower_terms)))
+    hits = list(lower_topics.intersection(lower_terms))
 
     return sorted(t for t in topics if t.lower() in hits) + sorted(t for t in topics if t.lower() not in hits)


### PR DESCRIPTION
## Overview

This PR:

- Shows 10 topics by default, with the option to expand more.
- Shows topics matching the search query or selected facet first.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

![topics](https://user-images.githubusercontent.com/12176173/67987486-83e9a000-fbfb-11e9-81b9-2ad7b2d62ea6.gif)

### Notes

Yikes! We'd included jQuery and the Bootstrap JavaScript twice, breaking some functionality on the search page (e.g., the expand and collapse toggles on the topic filters). That's fixed in this PR.

## Testing Instructions

- Run the app as specified in the README, being sure to load some data into your Solr index.
- Search for "metro red line". Confirm that the tags on the result begin with "Metro Red Line", and that it is highlighted. Confirm the remaining tags are in alphabetical order.
- Select a topic from the topic filter. Confirm that the selected topic is highlighted, and that it is alphabetized with "Metro Red Line" accordingly, if the board report has both tags. 
- Confirm that only 10 tags are shown. If there are more than 10 tags, confirm that there is a "More topics..." link, and that clicking it reveals the rest of the tags.

Handles #492
