### PR TITLE
Update archive link text on the homepage

### DIFF
--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -33,7 +33,7 @@
                         </label>
                     </div>
                 </form><br />
-                <p class="archive-link"><a href="{% url 'lametro:archive-search' %}">Search the Metro Board Archive (1952-2015)</a></p>
+                <p class="archive-link"><a href="{% url 'lametro:archive-search' %}">Search the Metro Board Archive from 1952-2015 (Board Boxes 1994-Present)</a></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Overview

This PR updates the archive link text on the homepage, per #498.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

N/A

### Notes

N/A

## Testing Instructions

 * Run the application
 * Navigate to the homepage and confirm the archive link below the search bar reads `Search the Metro Board Archive from 1952-2015 (Board Boxes 1994-Present)`

Handles #498
