### PR TITLE
Repair map display on person detail pages

### DIFF
--- a/lametro/templates/lametro/person.html
+++ b/lametro/templates/lametro/person.html
@@ -6,7 +6,7 @@
 {% block title %}{{ person.name }}{% endblock %}
 
 {% block extra_css %}
-    {% if MAP_CONFIG %}
+    {% if map_geojson %}
         <link rel="stylesheet" href="{% static 'css/leaflet.css' %}" />
     {% endif %}
 {% endblock %}
@@ -56,7 +56,7 @@
                 <p class="small">{{ member_bio | safe }}</p>
             {% endif %}
 
-            {% if MAP_CONFIG %}
+            {% if map_geojson %}
                 <hr />
                 <h4>
                     {% if person.current_district %}
@@ -191,7 +191,7 @@
 
 {% block extra_js %}
 
-    {% if map_geojson_districts %}
+    {% if map_geojson %}
 
         <script src="{% static 'js/leaflet.js' %}" /></script>
         <script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false&libraries=places&v=3.17&key={{GOOGLE_API_KEY}}"></script>
@@ -219,7 +219,7 @@
                 mapOptions: {styles: google_map_styles}
             });
             map.addLayer(layer);
-            var geojson = L.geoJson({{ map_geojson_districts |safe }}, {
+            var geojson = L.geoJson({{ map_geojson |safe }}, {
                 style: {
                         "color": "#3D8A8E",
                         "weight": 1.2,


### PR DESCRIPTION
## Overview

This PR fixes the display of maps on the person detail pages. Sorry to hop out of my lane, @fgregg, but I was looking #361 (specifically whether it was addressed in the upgrade) and arrived at this change while debugging. Thought I'd submit a PR to save you the trouble!

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

N/A

### Notes

N/A

## Testing Instructions

 * If you haven't already, run a person scrape: `docker-compose run --rm scrapers pupa update lametro people --rpm=0`
 * Start the application: `docker-compose up app`
 * Navigate to the board members page and confirm the map still looks and behaves as expected: http://localhost:8011/board-members
 * Navigate to each board member detail page and confirm that all of them render a map, with the exception of John Bulinski, who represents the governor/state, i.e., does not have a shape.

Related to #361.
