### PR TITLE
person map using django serialize

### DIFF
--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.gis',
     'haystack',
     'opencivicdata.core',
     'opencivicdata.legislative',

--- a/lametro/templates/lametro/person.html
+++ b/lametro/templates/lametro/person.html
@@ -6,7 +6,7 @@
 {% block title %}{{ person.name }}{% endblock %}
 
 {% block extra_css %}
-    {% if MAP_CONFIG %}
+    {% if map_geojson %}
         <link rel="stylesheet" href="{% static 'css/leaflet.css' %}" />
     {% endif %}
 {% endblock %}
@@ -56,7 +56,7 @@
                 <p class="small">{{ member_bio | safe }}</p>
             {% endif %}
 
-            {% if MAP_CONFIG %}
+            {% if map_geojson %}
                 <hr />
                 <h4>
                     {% if person.current_district %}
@@ -191,8 +191,7 @@
 
 {% block extra_js %}
 
-    {% if map_geojson_districts %}
-
+    {% if map_geojson %}
         <script src="{% static 'js/leaflet.js' %}" /></script>
         <script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false&libraries=places&v=3.17&key={{GOOGLE_API_KEY}}"></script>
         <script type="text/javascript" src="{% static 'js/leaflet-google.js' %}" ></script>
@@ -219,7 +218,7 @@
                 mapOptions: {styles: google_map_styles}
             });
             map.addLayer(layer);
-            var geojson = L.geoJson({{ map_geojson_districts |safe }}, {
+            var geojson = L.geoJson({{ map_geojson |safe }}, {
                 style: {
                         "color": "#3D8A8E",
                         "weight": 1.2,

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -38,6 +38,7 @@ from django.views.generic import TemplateView
 from django.http import HttpResponse, HttpResponseRedirect, HttpResponsePermanentRedirect, HttpResponseNotFound
 from django.shortcuts import render_to_response, redirect
 from django.core import management
+from django.core.serializers import serialize
 from django.views.generic import View
 from django.views.decorators.csrf import csrf_exempt
 
@@ -517,12 +518,21 @@ class LAPersonDetailView(PersonDetailView):
         return response
 
     def get_context_data(self, **kwargs):
-        post_model = LAMetroPost
 
         context = super().get_context_data(**kwargs)
         person = context['person']
 
-        context['qualifying_post'] = person.current_council_seat.post.acting_label
+        council_post = person.current_council_seat.post
+
+        context['qualifying_post'] = council_post.acting_label
+
+        if council_post.shape:
+            context['map_geojson'] = serialize('geojson',
+                                               [council_post],
+                                               geometry_field='shape',
+                                               fields=())
+        else:
+            context['map_geojson'] = None
 
         if person.committee_sponsorships:
             context['sponsored_legislation'] = person.committee_sponsorships


### PR DESCRIPTION
## Overview

Restores maps to individual person pages. closes #361

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

@hancush [had a mixin strategy](https://github.com/datamade/la-metro-councilmatic/pull/517) that factored out some code and was used in both the person map and the board map. This code uses some builtin code from django, and scans a bit easier to me.


## Testing Instructions


 * If you haven't already, run a person scrape: `docker-compose run --rm scrapers pupa update lametro people --rpm=0`
 * Start the application: `docker-compose up app`
 * Navigate to the board members page and confirm the map still looks and behaves as expected: http://localhost:8011/board-members
 * Navigate to each board member detail page and confirm that all of them render a map, with the exception of John Bulinski, who represents the governor/state, i.e., does not have a shape.

Handles #361
