### PR TITLE
Restore event tests

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -468,7 +468,7 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
                 # to show board meetings first, so order in reverse, since False
                 # (0) comes before True (1).
                 current_meetings = scheduled_meetings.filter(start_time__gte=twenty_minutes_ago)\
-                                                     .annotate(is_board_meeting=RawSQL("name like %s", ('%Board Meeting%',)))\
+                                                     .annotate(is_board_meeting=RawSQL("opencivicdata_event.name like %s", ('%Board Meeting%',)))\
                                                      .order_by('-is_board_meeting')
 
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,7 +223,7 @@ def membership(db, metro_organization, metro_person):
                 'id': randrange(10000),
                 'organization': related_org,
                 'person': related_person,
-                'end_date': (datetime.now() + timedelta(days=1)).date() 
+                'end_date': (datetime.now() + timedelta(days=1)).date().isoformat()
             }
 
             membership_info.update(kwargs)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -62,20 +62,23 @@ def concurrent_current_meetings(event):
     board_meeting_info = {
         'id': 'ocd-event/ef33b22d-b166-458f-b254-b81f656ffc09',
         'name': 'Regular Board Meeting',
-        'start_date': LAMetroEvent._time_from_now(minutes=3),
+        'start_date': LAMetroEvent._time_from_now(minutes=3)\
+            .replace(second=0, microsecond=0)\
+            .isoformat(),
     }
     board_meeting = event.build(**board_meeting_info)
 
     construction_meeting_info = {
         'id': 'ocd-event/FEC6A621-F5C7-4A88-B2FB-5F6E14FE0E35',
         'name': 'Construction Committee',
-        'start_date': LAMetroEvent._time_from_now(minutes=3),
+        'start_date': LAMetroEvent._time_from_now(minutes=3)\
+            .replace(second=0, microsecond=0)\
+            .isoformat(),
     }
     construction_meeting = event.build(**construction_meeting_info)
 
     return board_meeting, construction_meeting
 
-@pytest.mark.skip("need to fix start date upstream in python-opencivicdata")
 def test_current_meeting_streaming_event(concurrent_current_meetings, mocker):
     '''
     Test that if an event is streaming, it alone is returned as current.
@@ -98,8 +101,6 @@ def test_current_meeting_streaming_event(concurrent_current_meetings, mocker):
     # Assert that we returned the streaming meeting.
     assert current_meetings.get() == live_meeting
 
-
-@pytest.mark.skip("need to fix start date upstream in python-opencivicdata")
 def test_current_meeting_no_streaming_event(concurrent_current_meetings,
                                             mocker):
     '''
@@ -120,7 +121,6 @@ def test_current_meeting_no_streaming_event(concurrent_current_meetings,
     # Test that both meetings are returned.
     assert all(m in current_meetings for m in concurrent_current_meetings)
 
-@pytest.mark.skip("need to fix start date upstream in python-opencivicdata")
 def test_current_meeting_no_streaming_event_late_start(event, mocker):
     '''
     Test that if an meeting is scheduled but not yet streaming, it is returned
@@ -130,7 +130,9 @@ def test_current_meeting_no_streaming_event_late_start(event, mocker):
     crenshaw_meeting_info = {
         'id': 'ocd-event/3c93e81f-f1a9-42ce-97fe-30c77a4a6740',
         'name': 'Crenshaw Project Corporation',
-        'start_date': LAMetroEvent._time_ago(minutes=15),
+        'start_date': LAMetroEvent._time_ago(minutes=15)\
+            .replace(second=0, microsecond=0)\
+            .isoformat(),
     }
     late_current_meeting = event.build(**crenshaw_meeting_info)
 
@@ -145,7 +147,6 @@ def test_current_meeting_no_streaming_event_late_start(event, mocker):
     # Assert that we returned the late meeting.
     assert current_meetings.get() == late_current_meeting
 
-@pytest.mark.skip("need to fix start date upstream in python-opencivicdata")
 def test_current_meeting_no_potentially_current(event):
     '''
     Test that if there are no potentially current meetings (scheduled to
@@ -156,7 +157,9 @@ def test_current_meeting_no_potentially_current(event):
     safety_meeting_info = {
         'id': 'ocd-event/5e84e91d-279c-4c83-a463-4a0e05784b62',
         'name': 'System Safety, Security and Operations Committee',
-        'start_date': LAMetroEvent._time_from_now(hours=12),
+        'start_date': LAMetroEvent._time_from_now(hours=12)\
+            .replace(second=0, microsecond=0)\
+            .isoformat(),
     }
     event.build(**safety_meeting_info)
 


### PR DESCRIPTION
## Overview

This PR restores previously skipped tests of events by adjusting the tests and making one small alteration to a model method.


## Testing Instructions

```
docker-compose run --rm app pytest
```
