### PR TITLE
Restore bill filtering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ branches:
   only:
   - "/^v0.*$/"
   - 2.5
+  - "2.5_deploy"
   - master
 language: python
 python:

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -63,14 +63,21 @@ class LAMetroBillManager(models.Manager):
         when getting bill querysets. Otherwise restricted view bills
         may slip through the crevices of Councilmatic display logic.
         '''
-        filtered_qs = super().get_queryset()\
-                             .exclude(restrict_view=True)\
-                             .filter(Q(eventrelatedentity__agenda_item__event__status='passed') | \
-                                     Q(eventrelatedentity__agenda_item__event__status='cancelled') | \
-                                     Q(bill_type='Board Box'))\
-                             .distinct()
+        qs = super().get_queryset()
 
-        return filtered_qs
+        qs = qs.exclude(
+            restrict_view=True
+        ).annotate(board_box=Case(
+            When(bill__extras__local_classification='Board Box', then=True),
+            When(bill__classification__contains=['Board Box'], then=True),
+            default=False,
+            output_field=models.BooleanField()
+        )).filter(Q(eventrelatedentity__agenda_item__event__status='passed') | \
+                  Q(eventrelatedentity__agenda_item__event__status='cancelled') | \
+                  Q(board_box=True)
+        ).distinct()
+
+        return qs
 
 
 class LAMetroBill(Bill, SourcesMixin):

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -63,7 +63,12 @@ class LAMetroBillManager(models.Manager):
         when getting bill querysets. Otherwise restricted view bills
         may slip through the crevices of Councilmatic display logic.
         '''
-        filtered_qs = super().get_queryset()
+        filtered_qs = super().get_queryset()\
+                             .exclude(restrict_view=True)\
+                             .filter(Q(eventrelatedentity__agenda_item__event__status='passed') | \
+                                     Q(eventrelatedentity__agenda_item__event__status='cancelled') | \
+                                     Q(bill_type='Board Box'))\
+                             .distinct()
 
         return filtered_qs
 

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -66,7 +66,6 @@ def test_format_full_text(bill, text, subject):
 
     assert format_full_text(full_text) == subject
 
-@pytest.mark.skip("restore in separate PR")
 @pytest.mark.parametrize('restrict_view,bill_type,event_status,is_public', [
         (True, 'Board Box', 'passed', False),
         (False, 'Board Box', 'passed', True),
@@ -86,7 +85,7 @@ def test_bill_manager(bill,
     '''
     bill_info = {
         'classification': [bill_type],
-        'extras': {'restrict_view': restrict_view},
+        'restrict_view': restrict_view,
     }
     bill = bill.build(**bill_info)
 
@@ -99,7 +98,7 @@ def test_bill_manager(bill,
     event = related_entity.agenda_item.event
     event.status = event_status
     event.save()
-    
+
     event.refresh_from_db()
     related_entity.refresh_from_db()
 
@@ -111,7 +110,7 @@ def test_bill_manager(bill,
         bill_qs_with_manager = LAMetroBill.objects.filter(id=bill.id)
         assert is_public == (bill in bill_qs_with_manager)
 
-@pytest.mark.skip("going to address this upstream in the scraper")        
+@pytest.mark.skip("going to address this upstream in the scraper")
 @pytest.mark.django_db
 def test_last_action_date_has_already_occurred(bill, event):
     some_bill = bill.build()
@@ -125,7 +124,7 @@ def test_last_action_date_has_already_occurred(bill, event):
         some_event = event.build(id=id_fmt.format(uuid4()), start_date=t.date())
         item = some_event.agenda.create(order=1)
         item.related_entities.create(bill=some_bill)
-                                              
+
 
     # Assert the bill occurs on both agendas.
     assert Event.objects.filter(agenda__related_entities__bill=some_bill)\


### PR DESCRIPTION
## Overview

This PR restores filtering private bills from display, namely:

https://github.com/datamade/la-metro-councilmatic/blob/9a8c0dd232aac453696281d47d256fcb5d98d0d4/lametro/models.py#L49-L55

It also re-enables the test for the manager, which should now be passing.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Handled by re-enabled bill manager test.

Handles #508 (I think).
