### PR TITLE
Fix reference to event location in event partials

### DIFF
--- a/lametro/templates/partials/event_item.html
+++ b/lametro/templates/partials/event_item.html
@@ -15,7 +15,7 @@
       </span>
       {{event.start_time| date:"g:ia"}}<br/>
       <span class="desktop-only text-muted">
-        {{event.location_name}}<br />
+        {{event.location.name}}<br />
       </span>
     </small>
 

--- a/lametro/templates/partials/meeting_details_current.html
+++ b/lametro/templates/partials/meeting_details_current.html
@@ -42,7 +42,7 @@
                     <p class="small text-muted">
                         <i class="fa fa-fw fa-calendar-o"></i> {{ current_meeting.first.start_time | date:"D n/d/Y"}}<br/>
                         <i class="fa fa-fw fa-clock-o"></i> {{ current_meeting.first.start_time | date:"g:i a"}}<br/>
-                        <i class="fa fa-fw fa-map-marker"></i> {{ current_meeting.first.location_name}}<br />
+                        <i class="fa fa-fw fa-map-marker"></i> {{ current_meeting.first.location.name}}<br />
                     </p>
 
                     <!-- Links to media url and PDF download -->

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -21,7 +21,7 @@
             <p class="small text-muted">
               <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y"}}<br/>
               <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a"}}<br/>
-              <i class="fa fa-fw fa-map-marker"></i> {{ meeting.location_name}}<br />
+              <i class="fa fa-fw fa-map-marker"></i> {{ meeting.location.name}}<br />
             </p>
             {% if meeting.documents.all %}
             <div class="row">


### PR DESCRIPTION
## Overview

This PR updated references to event name to use the related event location object.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

N/A

### Notes

N/A

## Testing Instructions

* View the homepage and confirm that event location is displayed in the current/upcoming meeting block.
