### PR TITLE
Patch search index and result display bugs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
         condition: service_healthy
     environment:
       DATABASE_URL: 'postgis://postgres:@postgres/lametro'
+      DJANGO_SETTINGS_MODULE: 'pupa_settings'
+      SHARED_DB: "True"
     command: sh -c 'pupa update --rpm=600 lametro people && pupa update --rpm=600 lametro bills window=30 && pupa update --rpm=600 lametro events'
 
 volumes:

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -42,13 +42,16 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         return obj.topics
 
     def prepare_attachment_text(self, obj):
-        return ' '.join(d.extras['full_text'] for d in obj.documents.all() if d.full_text)
+        return ' '.join(
+            d.extras['full_text'] for d in obj.documents.all()
+            if d.extras.get('full_text')
+        )
 
     def prepare_legislative_session(self, obj):
         start_year = obj.legislative_session.identifier
         end_year = int(start_year) + 1
 
-        session = '7/1/{start_year} to 6/30/{end_year}'.format(start_year=start_year, 
+        session = '7/1/{start_year} to 6/30/{end_year}'.format(start_year=start_year,
                                                                end_year=end_year)
-        
+
         return session

--- a/lametro/templates/partials/tags.html
+++ b/lametro/templates/partials/tags.html
@@ -7,8 +7,8 @@
 
 {% if result.object.primary_sponsor %}
     <p class="small text-muted condensed">
-        <i class="fa fa-fw fa-user"></i>
-        {{result.object.primary_sponsor.person.name}}
+        <i class="fa fa-fw fa-users"></i>
+        {{result.object.primary_sponsor.name}}
     </p>
 {% endif %}
 


### PR DESCRIPTION
## Overview

This PR:

- Patches a bug that, in conjunction with https://github.com/datamade/django-councilmatic/commit/ea5cfb120c0c6e4581de1170d03106bbd9fb88ed, prevented attachment text from being indexed properly, closes #539.
- Gets `name` directly from the primary sponsorship object. I also made a fix upstream (https://github.com/datamade/django-councilmatic/commit/905bc1047d28dbb03e1bb4cf8f8dfc5a7fce4d30) for the default tags partial.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

N/A

### Notes

N/A

## Testing Instructions

 * Assuming you have a local database, run the application locally: `docker-compose up -d app`
 * If you haven't already, convert attachment text: `docker-compose exec app python manage.py convert_attachment_text --update_all`
 * Rebuild your search index: `docker-compose exec app python manage.py rebuild_index --batch-size=100`
 * Run a search across all documents. Note the result count.
 * Limit your search to report text only. Confirm that the result count has decreased.
 * On the search page, confirm that the primary sponsor is displayed correctly with each search result.
