### PR TITLE
Move logic to handle missing histories upstream

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -132,22 +132,6 @@ class LAMetroBill(Bill, SourcesMixin):
     def controlling_body(self):
         return self.from_organization
 
-    def get_last_action_date(self):
-        '''
-        Several Metro bills do not have "histories."
-        Discussed in this issue:
-        https://github.com/datamade/la-metro-councilmatic/issues/340
-
-        If a bill does not have a history, then determine its `last_action_date` by
-        looking for the most recent agenda that references the bill. Consider only
-        events that have already occurred, so the last action date is not in the
-        future.
-        '''
-        try:
-            return self.actions.last().date_dt
-        except AttributeError:
-            return None
-
     @property
     def topics(self):
         return sorted(self.subject)

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -20,13 +20,6 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
     def prepare_sponsorships(self, obj):
         return [action.organization for action in obj.actions.all()]
 
-    def prepare_last_action_date(self, obj):
-        # Solr seems to be fussy about the time format, and we do not need the time, just the date stamp.
-        # https://lucene.apache.org/solr/guide/7_5/working-with-dates.html#date-formatting
-        last_action_date = obj.get_last_action_date()
-        if last_action_date:
-            return last_action_date.date()
-
     def prepare_sort_name(self, obj):
         full_text = obj.extras.get('plain_text')
         results = ''

--- a/lametro/templates/lametro/legislation.html
+++ b/lametro/templates/lametro/legislation.html
@@ -164,7 +164,7 @@
 
                                         {{bill.inferred_status | inferred_status_label | safe}}
                                     </td>
-                                    <td class='text-muted small' align='right'>{{ bill.get_last_action_date|date:'n/d/Y' }}</td>
+                                    <td class='text-muted small' align='right'>{{ bill.last_action_date|date:'n/d/Y' }}</td>
                                 </tr>
                             {% endwith %}
                             {% endfor %}

--- a/lametro/templates/partials/legislation_item.html
+++ b/lametro/templates/partials/legislation_item.html
@@ -23,7 +23,7 @@
 </div>
 
 <p>
-    <span class="small text-muted"><i class="fa fa-fw fa-calendar-o"></i> {{legislation.get_last_action_date|date:'n/d/Y'}} - {{legislation.current_action.description | remove_action_subj }}</span><br/>
+    <span class="small text-muted"><i class="fa fa-fw fa-calendar-o"></i> {{legislation.last_action_date|date:'n/d/Y'}} - {{legislation.current_action.description | remove_action_subj }}</span><br/>
 
     {% if legislation.topics %}
         <i class="fa fa-fw fa-tag"></i>

--- a/lametro/templates/partials/tags.html
+++ b/lametro/templates/partials/tags.html
@@ -1,7 +1,7 @@
 {% load extras %}
 {% load lametro_extras %}
 <p class="small text-muted condensed">
-  <i class="fa fa-fw fa-calendar-o"></i> {{result.object.get_last_action_date|date:'n/d/Y'}} - {{result.object.current_action.description | remove_action_subj }} (most recent action)
+  <i class="fa fa-fw fa-calendar-o"></i> {{result.last_action_date|date:'n/d/Y'}} - {{result.object.current_action.description | remove_action_subj }} (most recent action)
 </p>
 
 

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -110,7 +110,6 @@ def test_bill_manager(bill,
         bill_qs_with_manager = LAMetroBill.objects.filter(id=bill.id)
         assert is_public == (bill in bill_qs_with_manager)
 
-@pytest.mark.skip("going to address this upstream in the scraper")
 @pytest.mark.django_db
 def test_last_action_date_has_already_occurred(bill, event):
     some_bill = bill.build()
@@ -125,12 +124,11 @@ def test_last_action_date_has_already_occurred(bill, event):
         item = some_event.agenda.create(order=1)
         item.related_entities.create(bill=some_bill)
 
-
     # Assert the bill occurs on both agendas.
     assert Event.objects.filter(agenda__related_entities__bill=some_bill)\
                         .count() == 2
 
-    last_action_date = some_bill.get_last_action_date()
+    last_action_date = some_bill.councilmatic_bill.get_last_action_date()
 
     # Assert the last action matches the event that has already occurred.
-    assert last_action_date == two_weeks_ago
+    assert last_action_date.date() == two_weeks_ago.date()


### PR DESCRIPTION
## Overview

See https://github.com/datamade/django-councilmatic/pull/264.

## Related issues

Connects https://github.com/opencivicdata/scrapers-us-municipal/issues/300.

## Testing Instructions

 * Complete the testing instructions in https://github.com/datamade/django-councilmatic/pull/264.
 * Run the app: `docker-compose up -d app`.
 * Update your search index: `docker-compose exec app python manage.py update_index --age=1 --batch-size=100`
  * Run a few searches and confirm bills updated in the last two weeks (the window you ran the scrape on) have last action dates.