### PR TITLE
Reference the correct ID in search results

### DIFF
--- a/lametro/templates/partials/search_result.html
+++ b/lametro/templates/partials/search_result.html
@@ -19,7 +19,7 @@
                 {% if r.highlighted.text.0 %}
                     {{ r.highlighted.text.0|safe }}
                 {% else %}
-                    {% get_highlighted_attachment_text r.ocd_id as highlighted_text %}
+                    {% get_highlighted_attachment_text r.id as highlighted_text %}
                     {{ highlighted_text|safe}}
                 {% endif %}
             </p>


### PR DESCRIPTION
## Overview

This PR updates the reference to the field containing the OCD ID for search results. This patches a bug where results without highlighted text caused a server error when passing a null ID back to the `get_highlighted_attachment_text` template filter.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

N/A

### Notes

N/A

## Testing Instructions

 * Merge and deploy the change to the test site.
 * Search for "bat" and confirm that results are rendered as expected. ([Shortcut](https://lametro-upgrade.datamade.us/search/?q=bat&search-all=on).)

Handles #560.
