### PR TITLE
Add option to compile_pdfs that only creates Packet objects

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -585,8 +585,10 @@ class Packet(models.Model):
     def related_files(self):
         raise NotImplementedError()
 
-    def save(self, *args, **kwargs):
-        self._merge_docs()
+    def save(self, *args, merge=True, **kwargs):
+        if merge:
+            self._merge_docs()
+
         self.url = settings.MERGER_BASE_URL + '/document/' + self.related_entity.slug
         super().save(*args, **kwargs)
 

--- a/scripts/lametro-staging-crontasks
+++ b/scripts/lametro-staging-crontasks
@@ -2,8 +2,8 @@
 APPDIR=/home/datamade/lametro-staging
 PYTHONDIR=/home/datamade/.virtualenvs/lametro-staging/bin/python
 
-# TODO: Sort out a way to use existing packets, rather than regenerating them
-# for both staging _and_ production.
+# TODO: Run compile_pdbs with the --db_only option once we deploy to
+# production.
 
 # TODO: Remove this once we deploy to production.
 10,25,40 * * * * datamade /usr/bin/flock -n /tmp/lametro_staging_dataload.lock -c 'cd $APPDIR && $PYTHONDIR manage.py compile_pdfs >> /var/log/councilmatic/lametro-compilepdfs.log 2>&1 && $PYTHONDIR manage.py convert_attachment_text >> /var/log/councilmatic/lametro-convertattachments.log 2>&1 && $PYTHONDIR manage.py update_index --batch-size=100 --age=1 >> /var/log/councilmatic/lametro-updateindex.log 2>&1 && $PYTHONDIR manage.py data_integrity >> /var/log/councilmatic/lametro-integrity.log 2>&1'


### PR DESCRIPTION
## Overview

See title. This is needed so we can use packets compiled for the main site for the staging instance of the upgrade.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs
