### PR TITLE
Add online public comment to event detail page

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '2.4'
 services:
   app:
-    image: lametro
-    container_name: lametro
+    image: lametro:legacy
+    container_name: lametro-legacy
     restart: always
     build: .
     stdin_open: true
@@ -44,7 +44,7 @@ services:
     environment:
       POSTGRES_DB: lametro
     volumes:
-      - lametro-db-data:/var/lib/postgresql/data
+      - lametro-legacy-db-data:/var/lib/postgresql/data
     ports:
       - 32001:5432
 
@@ -53,7 +53,7 @@ services:
     container_name: lametro-solr
     volumes:
       - ./solr_configs:/la-metro-councilmatic_configs
-      - lametro-solr-data:/opt/solr/server/solr/mycores
+      - lametro-legacy-solr-data:/opt/solr/server/solr/mycores
     command: sh -c 'solr-create -c lametro -d /la-metro-councilmatic_configs'
     ports:
       - 8986:8983
@@ -62,5 +62,5 @@ services:
     restart: on-failure
 
 volumes:
-  lametro-solr-data:
-  lametro-db-data:
+  lametro-legacy-solr-data:
+  lametro-legacy-db-data:

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -486,10 +486,7 @@ class LAMetroEvent(Event, LiveMediaMixin):
 
     @property
     def ecomment(self):
-        '''
-        TODO: Replace '#' with None when done testing!
-        '''
-        return self.extras.get('ecomment', '#')
+        return self.extras.get('ecomment', None)
 
 
 class LAMetroEventMedia(EventMedia):

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -484,6 +484,13 @@ class LAMetroEvent(Event, LiveMediaMixin):
             else:
                 return doc.url
 
+    @property
+    def ecomment(self):
+        '''
+        TODO: Replace '#' with None when done testing!
+        '''
+        return self.extras.get('ecomment', '#')
+
 
 class LAMetroEventMedia(EventMedia):
 

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -48,6 +48,25 @@
                 {% endif %}
             </p>
 
+            {% if event.ecomment %}
+                <div class="row">
+                    <div class="col-md-7">
+                        <p><strong>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</strong> Nulla fringilla imperdiet nisi, vel convallis ante dictum eu. Phasellus at varius purus, eget ultricies odio. Proin tincidunt pulvinar quam, et ullamcorper mi ornare in.</p>
+
+                        <p>
+                            <button class="btn btn-primary" href="{{ event.ecomment }}" target="_blank">
+                                <i class='fa fa-fw fa-external-link'></i>
+                                View online public comment
+                            </button>
+                        </p>
+                    </div>
+                </div>
+            {% else %}
+                <p class="small">
+                    <em>Online public comment is not available for this meeting.</em>
+                </p>
+            {% endif %}
+
             <hr />
 
             <div class="row">

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -51,12 +51,12 @@
             {% if event.ecomment %}
                 <div class="row">
                     <div class="col-md-7">
-                        <p><strong>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</strong> Nulla fringilla imperdiet nisi, vel convallis ante dictum eu. Phasellus at varius purus, eget ultricies odio. Proin tincidunt pulvinar quam, et ullamcorper mi ornare in.</p>
+                        <p>Now you can submit your comments to the Metro Board of Directors before meetings. Use the link below to comment on Board Reports on the agenda for the meeting of the <strong>{{ event.name }}</strong> on <strong>{{ event.start_time | date:"l, F d, Y" }}</strong>.</p>
 
                         <p>
                             <button class="btn btn-primary" href="{{ event.ecomment }}" target="_blank">
                                 <i class='fa fa-fw fa-external-link'></i>
-                                View online public comment
+                                Go to online public comment
                             </button>
                         </p>
                     </div>


### PR DESCRIPTION
## Overview

This pull request adds a link to online public comment to the events page.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="1440" alt="Screen Shot 2020-03-16 at 11 59 36 AM" src="https://user-images.githubusercontent.com/12176173/76782084-bd234680-677d-11ea-8f79-0d505b209dae.png">
<em>An event with an ecomment link</em>

<img width="1440" alt="Screen Shot 2020-03-16 at 11 59 50 AM" src="https://user-images.githubusercontent.com/12176173/76782091-c01e3700-677d-11ea-9c70-9b0f690d7777.png">
<em>An event without an ecomment link</em>
