### PR TITLE
Show cancelled board meetings on the homepage

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -324,7 +324,6 @@ class LAMetroEvent(Event, LiveMediaMixin):
     @classmethod
     def upcoming_board_meeting(cls):
         return cls.objects.filter(start_time__gt=datetime.now(app_timezone), name__icontains='Board Meeting')\
-                          .exclude(status='cancelled')\
                           .order_by('start_time')\
                           .first()
 

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -12,16 +12,28 @@
           <div class="col-xs-12">
             <!-- Meeting name -->
             <h4>
-              {{  meeting.link_html | safe }}<br/>
+              {% if meeting.status == 'cancelled' %}
+                <strike>{{  meeting.link_html | safe }}</strike> <small><span class="label label-stale">Cancelled</span></small>
+              {% else %}
+                {{  meeting.link_html | safe }}
+              {% endif%}
+              <br/>
               <span class="small text-muted">{{ meeting.description }}</span>
             </h4>
 
             <!-- Meeting info -->
 
             <p class="small text-muted">
-              <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y"}}<br/>
-              <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a"}}<br/>
-              <i class="fa fa-fw fa-map-marker"></i> {{ meeting.location_name}}<br />
+              {% if meeting.status == 'cancelled' %}
+                <strike>
+                  <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y" }}<br/>
+                  <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a" }}<br/>
+                </strike>
+              {% else %}
+                <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y" }}<br/>
+                <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a" }}<br/>
+                <i class="fa fa-fw fa-map-marker"></i> {{ meeting.location_name }}<br />
+              {% endif %}
             </p>
             {% if meeting.documents.all %}
             <div class="row">


### PR DESCRIPTION
## Overview

From @shrayshray:

> On 3/17, the 3/26 Regular Board Meeting was cancelled. After it was cancelled, the home page showed the nest Regular Board Meeting as 4/23. While 4/23 is technically the next time a Regular Board Meeting will take place, for a number of reasons, we still want to show the next meeting as 3/26, with the notation it is cancelled, until the date/time of the meeting passes.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="711" alt="Screen Shot 2020-03-23 at 3 29 59 PM" src="https://user-images.githubusercontent.com/12176173/77360396-4953e180-6d1b-11ea-8b35-279da44c7cb0.png">

## Testing Instructions

 * Deploy this PR to the staging site, then check to confirm the 3/26 board meeting appears as cancelled on the homepage.

Handles #573, part 1/2
