### PR TITLE
Remove sponsored board actions from board member page

### DIFF
--- a/lametro/templates/lametro/person.html
+++ b/lametro/templates/lametro/person.html
@@ -44,13 +44,8 @@
                 {% endif %}
             </p>
             <p class="small"><a href="/about/#about-la-metro"><i class="fa fa-info-circle" aria-hidden="true"></i> More about Metro appointments</a> </p>
-            
-            <hr />
 
-            {% if member_bio %}
-                <h4>About {{ person.name }}</h4>
-                <p class="small">{{ member_bio | safe }}</p>
-            {% endif %}
+            <hr />
 
             {% if map_geojson %}
                 <hr />
@@ -91,75 +86,40 @@
         </div>
 
         <div class='col-sm-8 no-pad-mobile'>
-            <ul class="nav nav-pills">
-                <li role="presentation" {% if request.GET.view == 'bills' or request.GET.view == None %}class='active' {% endif %}>
-                    <a href="/person/{{person.slug}}/?view=bills">
-                        <span class="small-pill">
-                            <i class='fa fa-fw fa-files-o'></i>
-                            <span class="desktop-only">Sponsored </span>
-                            Board Actions
-                        </span>
-                    </a>
-                </li>
-                <li role="presentation" {% if request.GET.view == 'committees' %}class='active' {% endif %}>
-                    <a href="{% url 'lametro:person' person.slug %}?view=committees">
-
-                        <span class="small-pill">
-                            <i class='fa fa-fw fa-group'></i>
-                            Committees
-                        </span>
-                    </a>
-                </li>
-            </ul>
-
-            {% if request.GET.view == 'bills' or request.GET.view == None %}
+            {% if member_bio %}
                 <h3>
-                    Sponsored Board Actions
+                    <i class="fa fa-user" aria-hidden="true"></i> About {{ person.name }}
                 </h3>
-                {% if sponsored_legislation %}
-                <p>Most recent actions sponsored by committees to which {{person.name}} belongs.</p><br/>
 
-                    {% for legislation in sponsored_legislation %}
-                        {% include "partials/legislation_item.html" %}
-                    {% endfor %}
-
-                    <hr />
-                    <p class="non-mobile-only">
-                        <a class='btn btn-primary' href="{% url 'lametro:person' person.slug %}?view=committees">Learn more about committees to which {{person.name}} belongs and view all actions they sponsor.<i class='fa fa-fw fa-chevron-right'></i></a>
-                    </p>
-                    <p class="mobile-only">
-                        <a class='btn btn-primary' href="{% url 'lametro:person' person.slug %}?view=committees">Learn more<i class='fa fa-fw fa-chevron-right'></i></a>
-                    </p>
-                {% else %}
-                    <p>The committees to which {{person.name}} belongs has not sponsored actions during {{person.name}}'s membership.</p>
-                {% endif %}
-
+                <p>{{ member_bio | safe }}</p><br />
             {% endif %}
 
-            {% if request.GET.view == 'committees' %}
-                <h3>Committees</h3>
-                {% if memberships_list %}
-                <div class="table-responsive">
-                    <table class='table table-responsive'>
-                        <thead>
+
+            {% if memberships_list %}
+            <h3>
+                <i class='fa fa-fw fa-group'></i> Committees
+            </h3>
+
+            <div class="table-responsive">
+                <table class='table table-responsive'>
+                    <thead>
+                        <tr>
+                            <th>Member of</th>
+                            <th>Position</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for membership in memberships_list %}
                             <tr>
-                                <th>Member of</th>
-                                <th>Position</th>
+                                <td>
+                                    <a href="{% url 'lametro:committee' membership.org_slug %}">{{membership.organization}}</a>
+                                </td>
+                                <td>{{membership.role}}</td>
                             </tr>
-                        </thead>
-                        <tbody>
-                            {% for membership in memberships_list %}
-                                <tr>
-                                    <td>
-                                        <a href="{% url 'lametro:committee' membership.org_slug %}">{{membership.organization}}</a>
-                                    </td>
-                                    <td>{{membership.role}}</td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-                {% endif %}
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
## Overview

See title.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="1440" alt="Screen Shot 2020-03-23 at 4 11 51 PM" src="https://user-images.githubusercontent.com/12176173/77363628-13b1f700-6d21-11ea-84a8-58660020efcf.png">

## Testing Instructions

 * Deploy this change to the staging site, then view board member pages and confirm bios, etc., are displayed, but sponsored actions are not.

Handles #567 
