### PR TITLE
Add ability to display multiple upcoming board meetings to the homepage

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -323,8 +323,10 @@ class LAMetroEvent(Event, LiveMediaMixin):
     @classmethod
     def upcoming_board_meetings(cls):
         '''
-        Return all meetings in the month of the next board meeting, so that any
-        special board meetings are also displayed on the homepage.
+        In rare instances, there are two board meetings in a given month, e.g.,
+        one regular meeting and one special meeting. Display both on the
+        homepage by returning all upcoming board meetings scheduled for the
+        month of the next upcoming meeting.
         '''
         board_meetings = cls.objects.filter(name__icontains='Board Meeting', start_time__gt=datetime.now(app_timezone))\
                                     .order_by('start_time')

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -320,13 +320,26 @@ class LAMetroEvent(Event, LiveMediaMixin):
     class Meta:
         proxy = True
 
-
     @classmethod
-    def upcoming_board_meeting(cls):
-        return cls.objects.filter(start_time__gt=datetime.now(app_timezone), name__icontains='Board Meeting')\
-                          .order_by('start_time')\
-                          .first()
+    def upcoming_board_meetings(cls):
+        now = datetime.now(app_timezone)
+        this_month = now.month
+        next_month = this_month + 1
 
+        # TODO: Add back Board Meeting filter here after testing
+        # >> name__icontains='Board Meeting'
+        board_meetings = cls.objects.filter(start_time__gt=now)
+
+        if board_meetings.filter(start_time__month=this_month).exists():
+            return board_meetings.filter(start_time__month=this_month)\
+                                 .order_by('start_time')
+
+        elif board_meetings.filter(start_time__month=next_month).exists():
+            return board_meetings.filter(start_time__month=next_month)\
+                                 .order_by('start_time')
+
+        else:
+            return board_meetings.order_by('start_time').first()
 
     @staticmethod
     def _time_ago(**kwargs):

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -326,9 +326,7 @@ class LAMetroEvent(Event, LiveMediaMixin):
         Return all meetings in the month of the next board meeting, so that any
         special board meetings are also displayed on the homepage.
         '''
-        # TODO: Add back Board Meeting filter here after testing
-        # >> name__icontains='Board Meeting'
-        board_meetings = cls.objects.filter(start_time__gt=datetime.now(app_timezone))\
+        board_meetings = cls.objects.filter(name__icontains='Board Meeting', start_time__gt=datetime.now(app_timezone))\
                                     .order_by('start_time')
 
         next_meeting = board_meetings.first()

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -322,24 +322,19 @@ class LAMetroEvent(Event, LiveMediaMixin):
 
     @classmethod
     def upcoming_board_meetings(cls):
-        now = datetime.now(app_timezone)
-        this_month = now.month
-        next_month = this_month + 1
-
+        '''
+        Return all meetings in the month of the next board meeting, so that any
+        special board meetings are also displayed on the homepage.
+        '''
         # TODO: Add back Board Meeting filter here after testing
         # >> name__icontains='Board Meeting'
-        board_meetings = cls.objects.filter(start_time__gt=now)
+        board_meetings = cls.objects.filter(start_time__gt=datetime.now(app_timezone))\
+                                    .order_by('start_time')
 
-        if board_meetings.filter(start_time__month=this_month).exists():
-            return board_meetings.filter(start_time__month=this_month)\
-                                 .order_by('start_time')
+        next_meeting = board_meetings.first()
 
-        elif board_meetings.filter(start_time__month=next_month).exists():
-            return board_meetings.filter(start_time__month=next_month)\
-                                 .order_by('start_time')
-
-        else:
-            return board_meetings.order_by('start_time').first()
+        return board_meetings.filter(start_time__month=next_meeting.start_time.month)\
+                             .order_by('start_time')
 
     @staticmethod
     def _time_ago(**kwargs):

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -71,11 +71,9 @@
                     <div class='col-sm-7'>
                         <h2>
                             <span class="non-mobile-only"><i class="fa fa-university" aria-hidden="true"></i></span>
-                            Next Board Meeting
+                            Next Board Meeting{% if upcoming_board_meetings|length > 1 %}s{% endif %}
                         </h2>
-                        {% with meeting=upcoming_board_meeting %}
-                            {% include "partials/meeting_details_next.html" %}
-                        {% endwith %}
+                        {% include "partials/meeting_details_next.html" %}
                     </div>
                     <div class='col-sm-5'>
                         {% include "partials/index_metro_description.html" %}

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -3,6 +3,7 @@
 
 <div>
   <div>
+    {% for meeting in upcoming_board_meetings %}
     <div class="row" style="margin-top: 1em;">
       <div class="col-xs-6">
         <img src='/static/images/Gateway03RT.jpg' class='img-responsive img-rounded' title='Los Angeles Gateway Plaza' alt="Los Angeles Gateway Plaza" />
@@ -46,16 +47,20 @@
         </div>
       </div>
     </div>
+    {% endfor %}
 
     <div class="row">
       <div class="col-xs-12">
-        <p class="small" style="padding-top: 10px;text-decoration: underline;"><strong>No meetings are in session at this time. The links to watch a meeting live, in English or Spanish, will be posted here once the meeting begins.</strong></p>
+        <p class="small" style="padding-top: 10px;text-decoration: underline;">
+          <strong>No meetings are in session at this time. The links to watch a meeting live, in English or Spanish, will be posted here once the meeting begins.</strong>
+        </p>
 
         <!-- Links to media url and PDF download -->
         {% if not meeting.documents.all %}
-        <p class="small"><em>Agenda will be posted no later than 72 hours prior to the start of the meeting, or 24 hours for Special Board meetings.</em></p>
+        <p class="small">
+          <em>Agenda will be posted no later than 72 hours prior to the start of the meeting, or 24 hours for Special Board meetings.</em>
+        </p>
         {% endif %}
-
       </div>
     </div>
   </div>

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -3,13 +3,13 @@
 
 <div>
   <div>
-    {% for meeting in upcoming_board_meetings %}
     <div class="row" style="margin-top: 1em;">
-      <div class="col-xs-6">
+      <div class="col-md-6">
         <img src='/static/images/Gateway03RT.jpg' class='img-responsive img-rounded' title='Los Angeles Gateway Plaza' alt="Los Angeles Gateway Plaza" />
       </div>
-      <div class="col-xs-6">
+      <div class="col-md-6">
         <div class="row">
+          {% for meeting in upcoming_board_meetings %}
           <div class="col-xs-12">
             <!-- Meeting name -->
             <h4>
@@ -44,10 +44,10 @@
             </div>
             {% endif %}
           </div>
+          {% endfor %}
         </div>
       </div>
     </div>
-    {% endfor %}
 
     <div class="row">
       <div class="col-xs-12">

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -56,7 +56,7 @@ class LAMetroIndexView(IndexView):
 
     def extra_context(self):
         extra = {}
-        extra['upcoming_board_meeting'] = self.event_model.upcoming_board_meeting()
+        extra['upcoming_board_meetings'] = self.event_model.upcoming_board_meetings()[:2]
         extra['current_meeting'] = self.event_model.current_meeting()
         extra['bilingual'] = bool([e for e in extra['current_meeting'] if e.bilingual])
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -259,7 +259,7 @@ def test_upcoming_board_meetings(event):
         ocd_id=get_event_id()
     )
 
-    # Create some meetings for the current month and year
+    # Create some meetings for the current date, i.e., upcoming meetings
     upcoming_board_meeting = event.build(
         name='Regular Board Meeting',
         start_time=thirty_seconds_from_now,


### PR DESCRIPTION
## Overview

This PR refactors `upcoming_board_meeting` into `upcoming_board_meetings` and updates the template on the homepage to allow for the display of multiple meetings.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="746" alt="Screen Shot 2020-03-26 at 2 11 51 PM" src="https://user-images.githubusercontent.com/12176173/77687037-db522900-6f6b-11ea-88b0-bb888d0cbe04.png">
<img width="471" alt="Screen Shot 2020-03-26 at 2 12 27 PM" src="https://user-images.githubusercontent.com/12176173/77687043-de4d1980-6f6b-11ea-84ed-4245cc10f64e.png">

Handles #577 
