### PR TITLE
Improve display on online public comment links

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -483,6 +483,10 @@ class LAMetroEvent(Event, LiveMediaMixin, eCommentMixin, SourcesMixin):
 
         Otherwise, return an empty queryset.
         '''
+        # TODO: Remove when ready to merge.
+        last_meeting = cls.objects.filter(documents__isnull=False)[:2]
+        return cls.objects.filter(id__in=[m.id for m in last_meeting])
+
         scheduled_meetings = cls._potentially_current_meetings()
 
         if scheduled_meetings:

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -371,11 +371,12 @@ class eCommentMixin(object):
 
     @property
     def ecomment_message(self):
-        if self.status == 'confirmed':
-            return self.UPCOMING_ECOMMENT_MESSAGE
+        if self.status != 'cancelled':
+            if self.start_time >= timezone.now():
+                return self.UPCOMING_ECOMMENT_MESSAGE
 
-        elif self.status == 'passed':
-            return self.PASSED_ECOMMENT_MESSAGE
+            else:
+                return self.PASSED_ECOMMENT_MESSAGE
 
 
 class LAMetroEvent(Event, LiveMediaMixin, eCommentMixin, SourcesMixin):

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -366,17 +366,20 @@ class eCommentMixin(object):
     PASSED_ECOMMENT_MESSAGE = 'Online public comment for this meeting has closed.'
 
     @property
+    def has_passed(self):
+        return self.start_time < timezone.now()
+
+    @property
     def ecomment_url(self):
         return self.extras.get('ecomment', None)
 
     @property
     def ecomment_message(self):
         if self.status != 'cancelled':
-            if self.start_time >= timezone.now():
-                return self.UPCOMING_ECOMMENT_MESSAGE
-
-            else:
+            if self.has_passed:
                 return self.PASSED_ECOMMENT_MESSAGE
+
+            return self.UPCOMING_ECOMMENT_MESSAGE
 
 
 class LAMetroEvent(Event, LiveMediaMixin, eCommentMixin, SourcesMixin):
@@ -515,7 +518,6 @@ class LAMetroEvent(Event, LiveMediaMixin, eCommentMixin, SourcesMixin):
             current_meetings = cls.objects.none()
 
         return current_meetings
-
 
     @classmethod
     def upcoming_committee_meetings(cls):

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -483,10 +483,6 @@ class LAMetroEvent(Event, LiveMediaMixin, eCommentMixin, SourcesMixin):
 
         Otherwise, return an empty queryset.
         '''
-        # TODO: Remove when ready to merge.
-        last_meeting = cls.objects.filter(documents__isnull=False)[:2]
-        return cls.objects.filter(id__in=[m.id for m in last_meeting])
-
         scheduled_meetings = cls._potentially_current_meetings()
 
         if scheduled_meetings:

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -304,7 +304,6 @@ class LiveMediaMixin(object):
     GENERIC_ENGLISH_MEDIA_URL = BASE_MEDIA_URL + 'camera_id=3'
     GENERIC_SPANISH_MEDIA_URL = BASE_MEDIA_URL + 'camera_id=2'
 
-
     @property
     def bilingual(self):
         '''
@@ -355,7 +354,31 @@ class LiveMediaMixin(object):
             return None
 
 
-class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
+class eCommentMixin(object):
+    UPCOMING_ECOMMENT_MESSAGE = (
+        'Online public comment will be available after the agenda is '
+        'posted and remain open until the meeting concludes. If you are '
+        'unable to access online public comment during the expected '
+        'time frame, please visit: <a href="https://metro.granicusideas.com/meetings" '
+        'target="_blank">https://metro.granicusideas.com/meetings</a>.'
+    )
+
+    PASSED_ECOMMENT_MESSAGE = 'Online public comment for this meeting has closed.'
+
+    @property
+    def ecomment_url(self):
+        return self.extras.get('ecomment', None)
+
+    @property
+    def ecomment_message(self):
+        if self.status == 'confirmed':
+            return self.UPCOMING_ECOMMENT_MESSAGE
+
+        elif self.status == 'passed':
+            return self.PASSED_ECOMMENT_MESSAGE
+
+
+class LAMetroEvent(Event, LiveMediaMixin, eCommentMixin, SourcesMixin):
     objects = LAMetroEventManager()
 
     class Meta:
@@ -507,10 +530,6 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
                                   .order_by('start_time').all()
 
         return meetings
-
-    @property
-    def ecomment(self):
-        return self.extras.get('ecomment', None)
 
 
 class EventAgendaItem(EventAgendaItem):

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -9,7 +9,14 @@
     <div class="row-fluid">
         <div class="col-sm-12">
             <br/>
-            <p><a href='/events/'><i class="fa fa-angle-double-left" aria-hidden="true"></i> Back to {{ CITY_VOCAB.EVENTS }} &amp; Agendas</a></p>
+            <p>
+                <a href='/events/'>
+                    <i class="fa fa-angle-double-left" aria-hidden="true"></i>
+                    Back to {{ CITY_VOCAB.EVENTS }} &amp; Agendas
+                </a>
+            </p>
+
+            <!-- Header -->
             <h1>
                 {% if event.status == 'cancelled' %}
                     <strike>{{event.name}}</strike> <small><span class="label label-stale">Cancelled</span></small>
@@ -20,64 +27,81 @@
                 {% for media in event.media.all %}
                     <a class="btn btn-salmon" href="{{ media.links.all.0.url }}" target="_blank"><i class= "fa fa-headphones" aria-hidden="true"></i> {% if media.note == 'Audio (SAP)' %}Ver en Español{% else %}Watch in English{% endif %}</a>
                 {% endfor %}
-
             </h1>
-            <p>{{event.description}}</p>
-            <p class="small text-muted">
-                {% if event.status == 'cancelled' %}
-                    <strike>
-                    <i class="fa fa-fw fa-calendar-o"></i> {{event.start_time | date:"D n/d/Y"}}<br/>
-                    <i class="fa fa-fw fa-clock-o"></i> {{event.start_time | date:"g:i a"}}<br/>
-                    </strike>
+
+            <div class="row">
+                {% if event.ecomment_url or not event.has_passed %}
+                <div class="col-sm-7">
                 {% else %}
-                    <i class="fa fa-fw fa-calendar-o"></i> {{event.start_time | date:"D n/d/Y"}}<br/>
-                    <i class="fa fa-fw fa-clock-o"></i> {{event.start_time | date:"g:i a"}}<br/>
-                    <i class="fa fa-fw fa-map-marker"></i> {{event.location.name}}
+                <div class="col-sm-12">
                 {% endif %}
-            </p>
 
-
-            {% comment %}
-            Online public comment is available for events until their start
-            date. If there is a public comment link, show it. Otherwise, if
-            the meeting has not yet passed, show the message about when it
-            will be available.
-            {% endcomment %}
-
-            {% if event.ecomment_url %}
-            <div class="row">
-                <div class="col-md-7">
-                    <p>
-                        <strong>You can submit your comments to the Metro Board of Directors before this meeting.</strong> Use the link below to comment on board reports on the agenda.
+                    <p>{{event.description}}</p>
+                    <p class="small text-muted">
+                        {% if event.status == 'cancelled' %}
+                            <strike>
+                            <i class="fa fa-fw fa-calendar-o"></i> {{event.start_time | date:"D n/d/Y"}}<br/>
+                            <i class="fa fa-fw fa-clock-o"></i> {{event.start_time | date:"g:i a"}}<br/>
+                            </strike>
+                        {% else %}
+                            <i class="fa fa-fw fa-calendar-o"></i> {{event.start_time | date:"D n/d/Y"}}<br/>
+                            <i class="fa fa-fw fa-clock-o"></i> {{event.start_time | date:"g:i a"}}<br/>
+                            <i class="fa fa-fw fa-map-marker"></i> {{event.location.name}}
+                        {% endif %}
                     </p>
 
-                    <p>
-                        <a class="btn btn-salmon" href="{{ event.ecomment_url }}" target="_blank">
-                            <i class='fa fa-fw fa-external-link'></i>
-                            Go to public comment
-                        </a>
-                    </p>
-                </div>
-            </div><br />
-            {% elif event.ecomment_message %}
-            <div class="row">
-                <div class="col-md-7">
-                    <p>{{ event.ecomment_message|safe }}</p>
-                </div>
-            </div><br />
-            {% endif %}
+                    {% if event.ecomment_url %}
+                        <p>
+                            <strong>You can submit your comments to the Metro Board of Directors before this meeting.</strong> Use the link below to comment on board reports on the agenda.
+                        </p>
 
-            <p class="small">
-                {% if event.web_source.url %}
-                    {% if not agenda_url and not uploaded_agenda_url and not uploaded_agenda_pdf %}
-                        Not seeing an agenda? Please use this link:<br>
+                        <p>
+                            <a class="btn btn-salmon" href="{{ event.ecomment_url }}" target="_blank">
+                                <i class='fa fa-fw fa-external-link'></i>
+                                Go to public comment
+                            </a>
+                        </p>
+                    {% elif event.ecomment_message %}
+                        <p>{{ event.ecomment_message|safe }}</p>
                     {% endif %}
-                    <a href='{{event.web_source.url}}' title='View on the {{CITY_VOCAB.SOURCE}} website' target="_blank">
-                        <i class='fa fa-fw fa-external-link'></i>
-                        View on the {{CITY_VOCAB.SOURCE}} website
-                    </a>
+
+                    <p class="small">
+                        {% if event.web_source.url %}
+                            {% if not agenda_url and not uploaded_agenda_url and not uploaded_agenda_pdf %}
+                                Not seeing an agenda? Please use this link:<br>
+                            {% endif %}
+                            <a href='{{event.web_source.url}}' title='View on the {{CITY_VOCAB.SOURCE}} website' target="_blank">
+                                <i class='fa fa-fw fa-external-link'></i>
+                                View on the {{CITY_VOCAB.SOURCE}} website
+                            </a>
+                        {% endif %}
+                    </p>
+                </div>
+
+                {% if event.ecomment_url or not event.has_passed %}
+                    <div class="col-sm-5">
+                        <h4>Submit public comment remotely</h4>
+                        <p>
+                            <strong>On the web:</strong>
+                            {% if event.ecomment_url %}
+                                <a href="{{ event.ecomment_url }}" target="_blank">
+                                    <i class='fa fa-fw fa-external-link'></i>
+                                    Go to public comment
+                                </a>
+                            {% else %}
+                                <a href="http://boardagendas.metro.net" target="_blank">http://boardagendas.metro.net</a> or <a href="https://metro.granicusideas.com/meetings" target="_blank">https://metro.granicusideas.com/meetings</a>
+                            {% endif %}<br />
+                            <strong>Via email:</strong> <a href="mailto:jacksonm@metro.net">jacksonm@metro.net</a><br />
+                            <strong>By postal mail:</strong> Board Secretary's Office, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012
+                        </p>
+
+                        <p>
+                            <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+                            <em>Please make sure to note the meeting name, meeting date, and agenda number or item along with comments submitted by email or postal mail.</em>
+                        </p>
+                    </div>
                 {% endif %}
-            </p>
+            </div>
 
             <hr />
 

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -48,7 +48,7 @@
             <div class="row">
                 <div class="col-md-7">
                     <p>
-                        You can submit your comments to the Metro Board of Directors before meetings. Use the link below to comment on Board Reports on the agenda for the meeting of the <strong>{{ event.name }}</strong> on <strong>{{ event.start_time | date:"l, F d, Y" }}</strong>.
+                        <strong>You can submit your comments to the Metro Board of Directors before this meeting.</strong> Use the link below to comment on board reports on the agenda.
                     </p>
 
                     <p>
@@ -56,20 +56,17 @@
                             <i class='fa fa-fw fa-external-link'></i>
                             Go to online public comment
                         </a>
-                        <br /><br />
                     </p>
                 </div>
-            </div>
+            </div><br />
             {% elif event.status == 'confirmed' %}
             <div class="row">
                 <div class="col-md-7">
-
-                    <p class="small">
-                        Online public comment will be available after the agenda is posted and remain open through the duration of the meeting. If you are unable to access online public comment during the expected time frame, please visit: <a href="https://metro.granicusideas.com/meetings" target="_blank">https://metro.granicusideas.com/meetings</a>.
+                    <p>
+                        <strong>You can submit your comments to the Metro Board of Directors before this meeting.</strong> Online public comment will be available after the agenda is posted and remain open through the duration of the meeting. If you are unable to access online public comment during the expected time frame, please visit: <a href="https://metro.granicusideas.com/meetings" target="_blank">https://metro.granicusideas.com/meetings</a>.
                     </p>
-
                 </div>
-            </div>
+            </div><br />
             {% endif %}
 
             <p class="small">

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -89,7 +89,7 @@
                                     Go to public comment
                                 </a>
                             {% else %}
-                                <a href="http://boardagendas.metro.net" target="_blank">http://boardagendas.metro.net</a> or <a href="https://metro.granicusideas.com/meetings" target="_blank">https://metro.granicusideas.com/meetings</a>
+                                <a href="https://metro.granicusideas.com/meetings" target="_blank">https://metro.granicusideas.com/meetings</a>
                             {% endif %}<br />
                             <strong>Via email:</strong> <a href="mailto:jacksonm@metro.net">jacksonm@metro.net</a><br />
                             <strong>By postal mail:</strong> Board Secretary's Office, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -36,6 +36,42 @@
                 {% endif %}
             </p>
 
+
+            {% comment %}
+            Online public comment is available for events until their start
+            date. If there is a public comment link, show it. Otherwise, if
+            the meeting has not yet passed, show the message about when it
+            will be available.
+            {% endcomment %}
+
+            {% if event.ecomment %}
+            <div class="row">
+                <div class="col-md-7">
+                    <p>
+                        You can submit your comments to the Metro Board of Directors before meetings. Use the link below to comment on Board Reports on the agenda for the meeting of the <strong>{{ event.name }}</strong> on <strong>{{ event.start_time | date:"l, F d, Y" }}</strong>.
+                    </p>
+
+                    <p>
+                        <a class="btn btn-salmon" href="{{ event.ecomment }}" target="_blank">
+                            <i class='fa fa-fw fa-external-link'></i>
+                            Go to online public comment
+                        </a>
+                        <br /><br />
+                    </p>
+                </div>
+            </div>
+            {% elif event.status == 'confirmed' %}
+            <div class="row">
+                <div class="col-md-7">
+
+                    <p class="small">
+                        Online public comment will be available after the agenda is posted and remain open through the duration of the meeting. If you are unable to access online public comment during the expected time frame, please visit: <a href="https://metro.granicusideas.com/meetings" target="_blank">https://metro.granicusideas.com/meetings</a>.
+                    </p>
+
+                </div>
+            </div>
+            {% endif %}
+
             <p class="small">
                 {% if event.web_source.url %}
                     {% if not agenda_url and not uploaded_agenda_url and not uploaded_agenda_pdf %}
@@ -47,25 +83,6 @@
                     </a>
                 {% endif %}
             </p>
-
-            {% if event.ecomment %}
-                <div class="row">
-                    <div class="col-md-7">
-                        <p>Now you can submit your comments to the Metro Board of Directors before meetings. Use the link below to comment on Board Reports on the agenda for the meeting of the <strong>{{ event.name }}</strong> on <strong>{{ event.start_time | date:"l, F d, Y" }}</strong>.</p>
-
-                        <p>
-                            <a class="btn btn-salmon" href="{{ event.ecomment }}" target="_blank">
-                                <i class='fa fa-fw fa-external-link'></i>
-                                Go to online public comment
-                            </a>
-                        </p>
-                    </div>
-                </div>
-            {% else %}
-                <p class="small">
-                    <em>Online public comment is not available for this meeting.</em>
-                </p>
-            {% endif %}
 
             <hr />
 

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -44,7 +44,7 @@
             will be available.
             {% endcomment %}
 
-            {% if event.ecomment %}
+            {% if event.ecomment_url %}
             <div class="row">
                 <div class="col-md-7">
                     <p>
@@ -52,19 +52,17 @@
                     </p>
 
                     <p>
-                        <a class="btn btn-salmon" href="{{ event.ecomment }}" target="_blank">
+                        <a class="btn btn-salmon" href="{{ event.ecomment_url }}" target="_blank">
                             <i class='fa fa-fw fa-external-link'></i>
-                            Go to online public comment
+                            Go to public comment
                         </a>
                     </p>
                 </div>
             </div><br />
-            {% elif event.status == 'confirmed' %}
+            {% elif event.ecomment_message %}
             <div class="row">
                 <div class="col-md-7">
-                    <p>
-                        <strong>You can submit your comments to the Metro Board of Directors before this meeting.</strong> Online public comment will be available after the agenda is posted and remain open through the duration of the meeting. If you are unable to access online public comment during the expected time frame, please visit: <a href="https://metro.granicusideas.com/meetings" target="_blank">https://metro.granicusideas.com/meetings</a>.
-                    </p>
+                    <p>{{ event.ecomment_message|safe }}</p>
                 </div>
             </div><br />
             {% endif %}

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -45,14 +45,14 @@
             <div class='col-sm-10 col-sm-offset-1'>
 
                 <div class="row">
-                    <div class='col-sm-7'>
+                    <div class='col-md-7'>
                         <h2>
                             <span class="non-mobile-only"><i class="fa fa-bell" aria-hidden="true"></i></span>
                             Current Meeting
                         </h2>
                         {% include "partials/meeting_details_current.html" %}
                     </div>
-                    <div class='col-sm-5'>
+                    <div class='col-md-5'>
                         {% include "partials/index_metro_description.html" %}
                     </div>
                 </div>
@@ -68,14 +68,14 @@
             <div class='col-sm-10 col-sm-offset-1'>
 
                 <div class="row">
-                    <div class='col-sm-7'>
+                    <div class='col-md-7'>
                         <h2>
                             <span class="non-mobile-only"><i class="fa fa-university" aria-hidden="true"></i></span>
                             Next Board Meeting{% if upcoming_board_meetings|length > 1 %}s{% endif %}
                         </h2>
                         {% include "partials/meeting_details_next.html" %}
                     </div>
-                    <div class='col-sm-5'>
+                    <div class='col-md-5'>
                         {% include "partials/index_metro_description.html" %}
                     </div>
                 </div>

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -93,6 +93,9 @@
                     <span class="non-mobile-only"><i class="fa fa-fw fa-group"></i> </span>
                     Upcoming Committee Meetings
                 </h2>
+                <p>
+                    <em>Click the name of each meeting below to view the meeting agenda and submit public comment.</em>
+                </p>
                 {% if upcoming_committee_meetings %}
                     {% if upcoming_committee_meetings %}
                         {% for event in upcoming_committee_meetings %}

--- a/lametro/templates/partials/event_item.html
+++ b/lametro/templates/partials/event_item.html
@@ -1,28 +1,29 @@
 <div class="row">
   <br/>
   <div class="col-xs-4">
-
-      {% if event.status == 'cancelled' %}<strike>{% endif %}
-
+    {% if event.status == 'cancelled' %}
+      <strike>
+    {% endif %}
       <small>
-      <i class="fa fa-fw fa-calendar-o"></i>
-      <span class="non-mobile-only"> 
-        {{event.start_time | date:"D"}}
-      </span>
-      {{event.start_time | date:"m/d"}}
-      <span class="non-mobile-only">
-        <i class="fa fa-fw fa-clock-o"></i> 
-      </span>
-      {{event.start_time| date:"g:ia"}}<br/>
-      <span class="desktop-only text-muted">
-        {{event.location.name}}<br />
-      </span>
-    </small>
-
-    {% if event.status == 'cancelled' %}</strike>{% endif %}
-
+        <i class="fa fa-fw fa-calendar-o"></i>
+        <span class="non-mobile-only">
+          {{event.start_time | date:"D"}}
+        </span>
+        {{event.start_time | date:"m/d"}}
+        <span class="non-mobile-only">
+          <i class="fa fa-fw fa-clock-o"></i>
+        </span>
+        {{event.start_time| date:"g:ia"}}<br/>
+        <span class="desktop-only text-muted">
+          {{event.location.name}}<br />
+        </span>
+      </small>
+    {% if event.status == 'cancelled' %}
+      </strike>
+    {% endif %}
   </div>
-  <div class="col-xs-8">
+
+  <div class="col-xs-4">
     <p>
       {% if event.status == 'cancelled' %}
         <strike>{{ event.link_html | safe }}</strike>
@@ -30,6 +31,17 @@
         <br/>
       {% else %}
         {{ event.link_html | safe }}<br/>
+      {% endif %}
+    </p>
+  </div>
+
+  <div class="col-xs-4">
+    <p>
+      {% if event.ecomment %}
+        <a class="btn btn-salmon btn-sm" href="{{ event.ecomment }}" target="_blank">
+          <i class='fa fa-fw fa-external-link'></i>
+          Online public comment
+        </a>
       {% endif %}
     </p>
   </div>

--- a/lametro/templates/partials/event_item.html
+++ b/lametro/templates/partials/event_item.html
@@ -1,6 +1,6 @@
 <div class="row">
   <br/>
-  <div class="col-xs-4">
+  <div class="col-xs-6 col-md-4">
     {% if event.status == 'cancelled' %}
       <strike>
     {% endif %}
@@ -23,7 +23,7 @@
     {% endif %}
   </div>
 
-  <div class="col-xs-4">
+  <div class="col-xs-6 col-md-4">
     <p>
       {% if event.status == 'cancelled' %}
         <strike>{{ event.link_html | safe }}</strike>
@@ -35,7 +35,7 @@
     </p>
   </div>
 
-  <div class="col-xs-4 text-center">
+  <div class="hidden-xs hidden-sm col-md-4 text-center">
     <p>
       {% if event.ecomment_url %}
         <a class="btn btn-salmon btn-sm" href="{{ event.ecomment_url }}" target="_blank">

--- a/lametro/templates/partials/event_item.html
+++ b/lametro/templates/partials/event_item.html
@@ -35,12 +35,12 @@
     </p>
   </div>
 
-  <div class="col-xs-4">
+  <div class="col-xs-4 text-center">
     <p>
-      {% if event.ecomment %}
-        <a class="btn btn-salmon btn-sm" href="{{ event.ecomment }}" target="_blank">
+      {% if event.ecomment_url %}
+        <a class="btn btn-salmon btn-sm" href="{{ event.ecomment_url }}" target="_blank">
           <i class='fa fa-fw fa-external-link'></i>
-          Online public comment
+          Go to public comment
         </a>
       {% endif %}
     </p>

--- a/lametro/templates/partials/meeting_details_current.html
+++ b/lametro/templates/partials/meeting_details_current.html
@@ -29,7 +29,7 @@
                                 </a>
                             {% endif %}
 
-                            {% if meeting.ecomment_link %}
+                            {% if meeting.ecomment_url %}
                                 <a class="btn btn-salmon" href="{{ event.ecomment_url }}" target="_blank">
                                     <i class='fa fa-fw fa-external-link'></i>
                                     Go to public comment
@@ -109,7 +109,7 @@
                             </a>
                         {% endif %}
 
-                        {% if current_meeting.first.ecomment_link %}
+                        {% if current_meeting.first.ecomment_url %}
                             <a class="btn btn-salmon" href="{{ current_meeting.first.ecomment_url }}" target="_blank" style="margin-top: 10px; margin-left: 5px;">
                                 <i class='fa fa-fw fa-external-link'></i>
                                 Go to public comment

--- a/lametro/templates/partials/meeting_details_current.html
+++ b/lametro/templates/partials/meeting_details_current.html
@@ -21,8 +21,16 @@
                             <p>
                                 {{ meeting.link_html | safe }}<br/>
                                 <span class="small text-muted">{{ meeting.description }}</span>
-                                {% if meeting.documents.all %}
-                                    <a class="" id="pdf-download-link" target='_blank' href='{{meeting.documents.all|find_agenda_url}}'><i class='fa fa-fw fa-download'></i> Get Agenda PDF</a><br>
+                                {% if meeting.ecomment_link %}
+                                    <a class="btn btn-teal" href="{{ event.ecomment_url }}" target="_blank">
+                                        <i class='fa fa-fw fa-external-link'></i>
+                                        Go to public comment
+                                    </a><br />
+                                {% elif meeting.documents.all %}
+                                    <a id="pdf-download-link" target='_blank' href='{{meeting.documents.all|find_agenda_url}}'>
+                                        <i class='fa fa-fw fa-download'></i>
+                                        Get Agenda PDF
+                                    </a><br />
                                 {% endif %}
                             </p>
                         {% endfor %}
@@ -72,8 +80,16 @@
                                 </div>
                             {% endif %}
                             <div class="col-sm-12">
-                                {% if current_meeting.first.documents.all %}
-                                    <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{ current_meeting.first.documents.all|find_agenda_url }}'><i class='fa fa-fw fa-download'></i> Get Agenda PDF</a>
+                                {% if current_meeting.first.ecomment_link %}
+                                    <a class="btn btn-teal" href="{{ event.ecomment_url }}" target="_blank">
+                                        <i class='fa fa-fw fa-external-link'></i>
+                                        Go to public comment
+                                    </a>
+                                {% elif current_meeting.first.documents.all %}
+                                    <a id="pdf-download-link" target='_blank' href='{{meeting.documents.all|find_agenda_url}}'>
+                                        <i class='fa fa-fw fa-download'></i>
+                                        Get Agenda PDF
+                                    </a>
                                 {% endif %}
                             </div>
                         {% endif %}

--- a/lametro/templates/partials/meeting_details_current.html
+++ b/lametro/templates/partials/meeting_details_current.html
@@ -4,6 +4,7 @@
 <div>
     <div>
         {% if current_meeting|length > 1 %}
+
             <div class="col-md-12">
                 <p>There are <strong>{{ current_meeting|length }}</strong> meetings in session:</p>
 

--- a/lametro/templates/partials/meeting_details_current.html
+++ b/lametro/templates/partials/meeting_details_current.html
@@ -3,101 +3,120 @@
 
 <div>
     <div>
-        <div class="row" style="margin-top: 1em;">
-            <div class="col-sm-6 current-meeting-img">
-                <img src='/static/images/Gateway03RT.jpg' class='img-responsive img-rounded' title='Los Angeles Gateway Plaza' alt="Los Angeles Gateway Plaza" />
-            </div>
-            <div class="col-sm-6">
-                <div class="row">
-                  <div class="col-sm-12">
-                    <!-- Meeting name(s) -->
-                    {% comment %}
-                    If there is more than one meeting, display the agenda
-                    download link with the corresponding meeting; otherwise,
-                    we'll show a download button, below.
-                    {% endcomment %}
-                    {% if current_meeting|length > 1 %}
-                        {% for meeting in current_meeting %}
-                            <p>
-                                {{ meeting.link_html | safe }}<br/>
-                                <span class="small text-muted">{{ meeting.description }}</span>
-                                {% if meeting.ecomment_link %}
-                                    <a class="btn btn-teal" href="{{ event.ecomment_url }}" target="_blank">
-                                        <i class='fa fa-fw fa-external-link'></i>
-                                        Go to public comment
-                                    </a><br />
-                                {% elif meeting.documents.all %}
-                                    <a id="pdf-download-link" target='_blank' href='{{meeting.documents.all|find_agenda_url}}'>
-                                        <i class='fa fa-fw fa-download'></i>
-                                        Get Agenda PDF
-                                    </a><br />
-                                {% endif %}
-                            </p>
-                        {% endfor %}
-                    {% else %}
+        {% if current_meeting|length > 1 %}
+            <div class="col-md-12">
+                <p>There are <strong>{{ current_meeting|length }}</strong> meetings in session:</p>
+
+                {% for meeting in current_meeting %}
+                    <p>
                         <h4>
-                          {{ current_meeting.first.link_html | safe }}<br/>
-                          <span class="small text-muted">{{ current_meeting.first.description }}</span>
+                            {{ meeting.link_html | safe }}<br/>
+                            <span class="small text-muted">{{ meeting.description }}</span>
                         </h4>
+
+                        <p class="small text-muted">
+                            <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y"}}<br/>
+                            <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a"}}<br/>
+                            <i class="fa fa-fw fa-map-marker"></i> {{ meeting.location.name }}<br />
+                        </p>
+
+                        <div class="text-center">
+                            {% if meeting.documents.all %}
+                                <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{ meeting.documents.all|find_agenda_url }}'>
+                                    <i class='fa fa-fw fa-download'></i>
+                                    Get Agenda PDF
+                                </a>
+                            {% endif %}
+
+                            {% if meeting.ecomment_link %}
+                                <a class="btn btn-salmon" href="{{ event.ecomment_url }}" target="_blank">
+                                    <i class='fa fa-fw fa-external-link'></i>
+                                    Go to public comment
+                                </a>
+                            {% endif %}
+                        </div>
+                    </p>
+                    <br />
+                {% endfor %}
+            </div>
+
+            <div class="text-center">
+                <p>
+                    <a class="btn btn-link" href="{{ current_meeting.first.GENERIC_ENGLISH_MEDIA_URL }}" target="_blank">
+                        <i class="fa fa-headphones" aria-hidden="true"></i>
+                        Watch in English
+                    </a>
+
+                    {% if bilingual %}
+                        <a class="btn btn-link" href="{{ current_meeting.first.GENERIC_SPANISH_MEDIA_URL }}" target="_blank">
+                            <i class="fa fa-headphones" aria-hidden="true"></i>
+                            Ver en Español
+                        </a>
                     {% endif %}
+                </p>
+            </div>
+
+        {% else %}
+
+            <!-- Display meeting details and image side by side -->
+            <div class="row" style="margin-top: 1em;">
+                <div class="col-md-6 current-meeting-img">
+                    <img src='/static/images/Gateway03RT.jpg' class='img-responsive img-rounded' title='Los Angeles Gateway Plaza' alt="Los Angeles Gateway Plaza" />
+                </div>
+
+                <div class="col-md-6">
+                    <h4>
+                      {{ current_meeting.first.link_html | safe }}<br/>
+                      <span class="small text-muted">{{ current_meeting.first.description }}</span>
+                    </h4>
 
                     <!-- Meeting info -->
-                    {% comment %}
-                    If there is more than one current meeting, they are
-                    all scheduled to begin at the same time, e.g., the start
-                    time of the first event will apply to all of them.
-                    {% endcomment %}
                     <p class="small text-muted">
                         <i class="fa fa-fw fa-calendar-o"></i> {{ current_meeting.first.start_time | date:"D n/d/Y"}}<br/>
                         <i class="fa fa-fw fa-clock-o"></i> {{ current_meeting.first.start_time | date:"g:i a"}}<br/>
                         <i class="fa fa-fw fa-map-marker"></i> {{ current_meeting.first.location.name}}<br />
                     </p>
 
-                    <!-- Links to media url and PDF download -->
-                    {% comment %}
-                    Display the generic URLs if there is more than one
-                    scheduled meeting. Otherwise, display the event-specific
-                    URL. If any of the scheduled meetings has Spanish audio,
-                    also display the Spanish URL.
-                    {% endcomment %}
-                    <div class="row">
-                        {% if current_meeting|length > 1 %}
-                            <div class="col-sm-12">
-                                <p><a class="btn btn-salmon" href="{{ current_meeting.first.GENERIC_ENGLISH_MEDIA_URL }}" target="_blank"><i class="fa fa-headphones" aria-hidden="true"></i> Watch in English</a></p>
-                            </div>
-                            {% if bilingual %}
-                                <div class="col-sm-12">
-                                    <p><a class="btn btn-salmon" href="{{ current_meeting.first.GENERIC_SPANISH_MEDIA_URL }}" target="_blank"><i class="fa fa-headphones" aria-hidden="true"></i> Ver en Español</a></p>
-                                </div>
-                            {% endif %}
-                        {% else %}
-                            <div class="col-sm-12">
-                                <p><a class="btn btn-salmon" href="{{ current_meeting.first.english_live_media_url }}" target="_blank"><i class="fa fa-headphones" aria-hidden="true"></i> Watch in English</a></p>
-                            </div>
-                            {% if bilingual %}
-                                <div class="col-sm-12">
-                                    <p><a class="btn btn-salmon" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank"><i class="fa fa-headphones" aria-hidden="true"></i> Ver en Español</a></p>
-                                </div>
-                            {% endif %}
-                            <div class="col-sm-12">
-                                {% if current_meeting.first.ecomment_link %}
-                                    <a class="btn btn-teal" href="{{ event.ecomment_url }}" target="_blank">
-                                        <i class='fa fa-fw fa-external-link'></i>
-                                        Go to public comment
-                                    </a>
-                                {% elif current_meeting.first.documents.all %}
-                                    <a id="pdf-download-link" target='_blank' href='{{meeting.documents.all|find_agenda_url}}'>
-                                        <i class='fa fa-fw fa-download'></i>
-                                        Get Agenda PDF
-                                    </a>
-                                {% endif %}
-                            </div>
-                        {% endif %}
-                    </div>
-                  </div>
+                    {% if current_meeting.first.documents.all %}
+                        <div class="text-center">
+                            <p>
+                                <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{ current_meeting.first.documents.all|find_agenda_url }}'>
+                                    <i class='fa fa-fw fa-download'></i>
+                                    Get Agenda PDF
+                                </a>
+                            </p>
+                        </div>
+                    {% endif %}
                 </div>
-                <br />
             </div>
-        </div>
+
+            <!-- Buttons -->
+            <div class="row">
+                <div class="col-md-12 text-center">
+                    <p>
+                        <a class="btn btn-salmon" href="{{ current_meeting.first.english_live_media_url }}" target="_blank" style="margin-top: 10px; margin-left: 5px;">
+                            <i class="fa fa-headphones" aria-hidden="true"></i>
+                            Watch in English
+                        </a>
+
+                        {% if bilingual %}
+                            <a class="btn btn-salmon" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank" style="margin-top: 10px; margin-left: 5px;">
+                                <i class="fa fa-headphones" aria-hidden="true"></i>
+                                Ver en Español
+                            </a>
+                        {% endif %}
+
+                        {% if current_meeting.first.ecomment_link %}
+                            <a class="btn btn-salmon" href="{{ current_meeting.first.ecomment_url }}" target="_blank" style="margin-top: 10px; margin-left: 5px;">
+                                <i class='fa fa-fw fa-external-link'></i>
+                                Go to public comment
+                            </a>
+                        {% endif %}
+                    </p>
+                </div>
+            </div>
+
+        {% endif %}
     </div>
 </div>
+

--- a/lametro/templates/partials/meeting_details_current.html
+++ b/lametro/templates/partials/meeting_details_current.html
@@ -39,22 +39,24 @@
                     </p>
                     <br />
                 {% endfor %}
-            </div>
 
-            <div class="text-center">
-                <p>
-                    <a class="btn btn-link" href="{{ current_meeting.first.GENERIC_ENGLISH_MEDIA_URL }}" target="_blank">
-                        <i class="fa fa-headphones" aria-hidden="true"></i>
-                        Watch in English
-                    </a>
+                <p class="small">These meetings will take place in succession. The broadcast for the second meeting will begin immediately after the first concludes.</p>
 
-                    {% if bilingual %}
-                        <a class="btn btn-link" href="{{ current_meeting.first.GENERIC_SPANISH_MEDIA_URL }}" target="_blank">
+                <div class="text-center">
+                    <p>
+                        <a class="btn btn-link" href="{{ current_meeting.first.GENERIC_ENGLISH_MEDIA_URL }}" target="_blank">
                             <i class="fa fa-headphones" aria-hidden="true"></i>
-                            Ver en Español
+                            Watch in English
                         </a>
-                    {% endif %}
-                </p>
+
+                        {% if bilingual %}
+                            <a class="btn btn-link" href="{{ current_meeting.first.GENERIC_SPANISH_MEDIA_URL }}" target="_blank">
+                                <i class="fa fa-headphones" aria-hidden="true"></i>
+                                Ver en Español
+                            </a>
+                        {% endif %}
+                    </p>
+                </div>
             </div>
 
         {% else %}

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -76,7 +76,7 @@
 
         {% if not upcoming_board_meetings|all_have_extra:'ecomment' %}
         <p class="small">
-          <em>{{ meeting.UPCOMING_ECOMMENT_MESSAGE|safe }}</em>
+          <em>{{ upcoming_board_meetings.first.UPCOMING_ECOMMENT_MESSAGE|safe }}</em>
         </p>
         {% endif %}
       </div>

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -45,10 +45,13 @@
             </div>
             {% endif %}
 
-            {% if meeting.ecomment %}
+            {% if meeting.ecomment_url %}
             <div class="row">
               <div class="col-xs-7">
-                <a class="btn btn-salmon" id="ecomment-link" target="_blank" href="{{ meeting.ecomment }}"><i class="fa fa-fw fa-external-link"></i> Go to public comment</a>
+                <a class="btn btn-salmon" target="_blank" href="{{ meeting.ecomment_url }}">
+                  <i class="fa fa-fw fa-external-link"></i>
+                  Go to public comment
+                </a>
               </div>
             </div>
             {% endif %}
@@ -73,7 +76,7 @@
 
         {% if not upcoming_board_meetings|all_have_extra:'ecomment' %}
         <p class="small">
-          <em>Online public comment will be available after an agenda is posted and remain open through the duration of the meeting. If you are unable to access online public comment during the expected time frame, please visit: <a href="https://metro.granicusideas.com/meetings" target="_blank">https://metro.granicusideas.com/meetings</a>.</em>
+          <em>{{ meeting.UPCOMING_ECOMMENT_MESSAGE|safe }}</em>
         </p>
         {% endif %}
       </div>

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -71,7 +71,7 @@
         </p>
         {% endif %}
 
-        {% if not upcoming_board_meetings|all_have_ecomment %}
+        {% if not upcoming_board_meetings|all_have_extra:'ecomment' %}
         <p class="small">
           <em>Online public comment will be available after an agenda is posted and remain open through the duration of the meeting. If you are unable to access online public comment during the expected time frame, please visit: <a href="https://metro.granicusideas.com/meetings" target="_blank">https://metro.granicusideas.com/meetings</a>.</em>
         </p>

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -23,7 +23,6 @@
             </h4>
 
             <!-- Meeting info -->
-
             <p class="small text-muted">
               {% if meeting.status == 'cancelled' %}
                 <strike>
@@ -36,10 +35,20 @@
                 <i class="fa fa-fw fa-map-marker"></i> {{ meeting.location.name }}<br />
               {% endif %}
             </p>
+
+            <!-- Supplementary links -->
             {% if meeting.documents.all %}
             <div class="row">
               <div class="col-xs-7">
                 <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{meeting.documents.all|find_agenda_url}}'><i class='fa fa-fw fa-download'></i> Get Agenda PDF</a>
+              </div>
+            </div>
+            {% endif %}
+
+            {% if meeting.ecomment %}
+            <div class="row">
+              <div class="col-xs-7">
+                <a class="btn btn-salmon" id="ecomment-link" target="_blank" href="{{ meeting.ecomment }}"><i class="fa fa-fw fa-external-link"></i> Go to public comment</a>
               </div>
             </div>
             {% endif %}
@@ -59,6 +68,12 @@
         {% if not meeting.documents.all %}
         <p class="small">
           <em>Agenda will be posted no later than 72 hours prior to the start of the meeting, or 24 hours for Special Board meetings.</em>
+        </p>
+        {% endif %}
+
+        {% if not upcoming_board_meetings|all_have_ecomment %}
+        <p class="small">
+          <em>Online public comment will be available after an agenda is posted and remain open through the duration of the meeting. If you are unable to access online public comment during the expected time frame, please visit: <a href="https://metro.granicusideas.com/meetings" target="_blank">https://metro.granicusideas.com/meetings</a>.</em>
         </p>
         {% endif %}
       </div>

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -192,5 +192,9 @@ def hits_first(context, topics, selected_topics):
     return sorted(t for t in topics if t.lower() in hits) + sorted(t for t in topics if t.lower() not in hits)
 
 @register.filter
-def all_have_ecomment(meetings):
-    return all(m.extras.get('ecomment', None) for m in meetings)
+def all_have_extra(entities, extra):
+    '''
+    Determine whether all entities in a given array have the designated value
+    in their extras.
+    '''
+    return all(e.extras.get(extra, None) for e in entities)

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -190,3 +190,7 @@ def hits_first(context, topics, selected_topics):
     hits = list(lower_topics.intersection(lower_terms))
 
     return sorted(t for t in topics if t.lower() in hits) + sorted(t for t in topics if t.lower() not in hits)
+
+@register.filter
+def all_have_ecomment(meetings):
+    return all(m.extras.get('ecomment', None) for m in meetings)

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -72,6 +72,7 @@ class LAMetroIndexView(IndexView):
     @property
     def extra_context(self):
         extra = {}
+
         extra['upcoming_board_meetings'] = self.event_model.upcoming_board_meetings()[:2]
         extra['current_meeting'] = self.event_model.current_meeting()
         extra['bilingual'] = bool([e for e in extra['current_meeting'] if e.bilingual])


### PR DESCRIPTION
## Overview

This PR:

- Adds eComment links to the upcoming board meetings and upcoming committee meetings on the homepage, connects #581, #583.
- Updates text shown on the event detail page when no eComment link is available, connects #582.
- Redesigns current meetings to display PDF link, both audio links, and the eComment link.
- Adds additional ways to submit public comment to upcoming event pages, connects #593.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

#### Homepage

_Upcoming board meeting without eComment:_

<img width="731" alt="Screen Shot 2020-04-06 at 3 52 37 PM" src="https://user-images.githubusercontent.com/12176173/78603993-ade46580-781e-11ea-92ed-18a5bae809a6.png">

_Upcoming board meeting with eComment:_

<img width="705" alt="Screen Shot 2020-04-06 at 3 52 13 PM" src="https://user-images.githubusercontent.com/12176173/78603988-ab820b80-781e-11ea-9f07-494cab2c8838.png">

_Upcoming committee meeting with eComment:_

<img width="1146" alt="Screen Shot 2020-04-06 at 3 54 35 PM" src="https://user-images.githubusercontent.com/12176173/78604188-0582d100-781f-11ea-8880-6599a0dfe182.png">

#### Event detail page

_Event detail without eComment:_

<img width="902" alt="Screen Shot 2020-04-06 at 3 54 54 PM" src="https://user-images.githubusercontent.com/12176173/78604226-15021a00-781f-11ea-8461-950617cd99bc.png">

_Event detail with eComment:_

<img width="915" alt="Screen Shot 2020-04-06 at 3 54 44 PM" src="https://user-images.githubusercontent.com/12176173/78604238-192e3780-781f-11ea-8048-1b79fdf576e2.png">
