### PR TITLE
Exclude relations to null bills in bill detail view

### DIFF
--- a/lametro/views.py
+++ b/lametro/views.py
@@ -94,6 +94,7 @@ class LABillDetail(BillDetailView):
 
         related_bills = context['legislation']\
             .related_bills\
+            .exclude(related_bill__isnull=True)\
             .annotate(latest_date=Max('related_bill__actions__date'))\
             .order_by('-latest_date')
 


### PR DESCRIPTION
## Overview

If related board reports are removed, the relationships are preserved. The board report detail view tries to reverse URLs for all related bills, but a null bill has a null slug, which breaks the view. This PR excludes null relations to solve this issue.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Deploy this change to staging and confirm that the following URLs load successfully:
   * https://lametro-upgrade.datamade.us/board-report/2016-0148/
   * https://lametro-upgrade.datamade.us/board-report/2017-0804/

Handles #590.
