### PR TITLE
Only display comment links for live meetings

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -355,12 +355,11 @@ class LiveMediaMixin(object):
 
 
 class eCommentMixin(object):
+    GENERIC_ECOMMENT_URL = 'https://metro.granicusideas.com/meetings'
+
     UPCOMING_ECOMMENT_MESSAGE = (
-        'Online public comment will be available after the agenda is '
-        'posted and remain open until the meeting concludes. If you are '
-        'unable to access online public comment during the expected '
-        'time frame, please visit: <a href="https://metro.granicusideas.com/meetings" '
-        'target="_blank">https://metro.granicusideas.com/meetings</a>.'
+        'Online public comment will be available on this page once the meeting '
+        'begins.'
     )
 
     PASSED_ECOMMENT_MESSAGE = 'Online public comment for this meeting has closed.'
@@ -371,7 +370,7 @@ class eCommentMixin(object):
 
     @property
     def ecomment_url(self):
-        return self.extras.get('ecomment', None)
+        return self.extras.get('ecomment', self.GENERIC_ECOMMENT_URL)
 
     @property
     def ecomment_message(self):
@@ -519,6 +518,7 @@ class LAMetroEvent(Event, LiveMediaMixin, eCommentMixin, SourcesMixin):
 
         return current_meetings
 
+
     @classmethod
     def upcoming_committee_meetings(cls):
         one_month_from_now = timezone.now() + relativedelta(months=1)
@@ -533,6 +533,16 @@ class LAMetroEvent(Event, LiveMediaMixin, eCommentMixin, SourcesMixin):
                                   .order_by('start_time').all()
 
         return meetings
+
+
+
+
+    @property
+    def show_comment(self):
+        return (
+            self in self._potentially_current_meetings() and
+            (self.ecomment_url or self._streaming_meeting() == self)
+        )
 
 
 class EventAgendaItem(EventAgendaItem):

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -520,10 +520,7 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
     @property
     def is_ongoing(self):
         if not hasattr(self, '_is_ongoing'):
-            self._is_ongoing = (
-                self in self._potentially_current_meetings() and
-                self in self._streaming_meeting()
-            )
+            self._is_ongoing = self in type(self).current_meeting()
 
         return self._is_ongoing
 

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -30,7 +30,7 @@
             </h1>
 
             <div class="row">
-                {% if event.ecomment_url or not event.has_passed %}
+                {% if has_agenda %}
                 <div class="col-sm-7">
                 {% else %}
                 <div class="col-sm-12">
@@ -50,9 +50,9 @@
                         {% endif %}
                     </p>
 
-                    {% if event.ecomment_url %}
+                    {% if event.show_comment %}
                         <p>
-                            <strong>You can submit your comments to the Metro Board of Directors before this meeting.</strong> Use the link below to comment on board reports on the agenda.
+                            <strong>You can submit your comments to the Metro Board of Directors during this meeting.</strong> Use the link below to comment on board reports on the agenda.
                         </p>
 
                         <p>
@@ -78,18 +78,18 @@
                     </p>
                 </div>
 
-                {% if event.ecomment_url or not event.has_passed %}
+                {% if has_agenda %}
                     <div class="col-sm-5">
                         <h4>Submit public comment remotely</h4>
                         <p>
-                            <strong>On the web:</strong>
-                            {% if event.ecomment_url %}
+                            {% if event.show_comment %}
+                                <strong>On the web:</strong>
                                 <a href="{{ event.ecomment_url }}" target="_blank">
                                     <i class='fa fa-fw fa-external-link'></i>
                                     Go to public comment
                                 </a>
                             {% else %}
-                                <a href="https://metro.granicusideas.com/meetings" target="_blank">https://metro.granicusideas.com/meetings</a>
+                                Online public comment will be available on this page once the meeting begins.
                             {% endif %}<br />
                             <strong>Via email:</strong> <a href="mailto:jacksonm@metro.net">jacksonm@metro.net</a><br />
                             <strong>By postal mail:</strong> Board Secretary's Office, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012
@@ -97,7 +97,7 @@
 
                         <p>
                             <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-                            <em>Please make sure to note the meeting name, meeting date, and agenda number or item along with comments submitted by email or postal mail.</em>
+                            <em>Please make sure to note the meeting name, meeting date, and agenda number or item along with comments submitted by email or postal mail. <strong>Comments via mail must be received by 5pm on the day prior to the meeting.</strong></em>
                         </p>
                     </div>
                 {% endif %}
@@ -117,7 +117,7 @@
                     {% endif %}
 
                     <!-- Check that the database has an agenda to display -->
-                    {% if agenda_url or uploaded_agenda_url or uploaded_agenda_pdf %}
+                    {% if has_agenda %}
 
                     <!-- An event can have both manually uploaded and auto-imported agendas, i.e., if a Metro Admin uploads an agenda and then import_data runs. Give the Admin an option to delete the manually uploaded agenda, but ONLY if an auto-imported agenda does not exist. -->
                     {% if not agenda_url%}

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -82,22 +82,22 @@
                     <div class="col-sm-5">
                         <h4>Submit public comment remotely</h4>
                         <p>
-                            {% if event.is_ongoing %}
-                                <strong>On the web:</strong>
-                                <a href="{{ event.ecomment_url }}" target="_blank">
-                                    <i class='fa fa-fw fa-external-link'></i>
-                                    Go to public comment
-                                </a>
-                            {% else %}
-                                Online public comment will be available on this page once the meeting begins.
-                            {% endif %}<br />
+                        {% if event.is_ongoing %}
+                            <strong>On the web:</strong>
+                            <a href="{{ event.ecomment_url }}" target="_blank">
+                                <i class='fa fa-fw fa-external-link'></i>
+                                Go to public comment
+                            </a>
+                        {% else %}
+                            {{ event.UPCOMING_ECOMMENT_MESSAGE }}
                             <strong>Via email:</strong> <a href="mailto:jacksonm@metro.net">jacksonm@metro.net</a><br />
                             <strong>By postal mail:</strong> Board Secretary's Office, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012
-                        </p>
+                        </p><br />
 
                         <p>
                             <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
                             <em>Please make sure to note the meeting name, meeting date, and agenda number or item along with comments submitted by email or postal mail. <strong>Comments via mail must be received by 5pm on the day prior to the meeting.</strong></em>
+                        {% endif %}
                         </p>
                     </div>
                 {% endif %}

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -81,23 +81,39 @@
                 {% if has_agenda and not event.has_passed %}
                     <div class="col-sm-5">
                         <h4>Submit public comment remotely</h4>
-                        <p>
                         {% if event.is_ongoing %}
-                            <strong>On the web:</strong>
-                            <a href="{{ event.ecomment_url }}" target="_blank">
-                                <i class='fa fa-fw fa-external-link'></i>
-                                Go to public comment
-                            </a>
-                        {% else %}
-                            <strong>Via email:</strong> <a href="mailto:jacksonm@metro.net">jacksonm@metro.net</a><br />
-                            <strong>By postal mail:</strong> Board Secretary's Office, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012
-                        </p>
 
-                        <p>
-                            <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-                            <em>Please make sure to note the meeting name, meeting date, and agenda number or item along with comments submitted by email or postal mail. <strong>Comments via mail must be received by 5pm on the day prior to the meeting.</strong></em>
+                            <p>
+                                <strong>On the web:</strong>
+                                <a href="{{ event.ecomment_url }}" target="_blank">
+                                    <i class='fa fa-fw fa-external-link'></i>
+                                    Go to public comment
+                                </a>
+                            </p>
+
+                        {% else %}
+
+                            <p>
+                                <strong>During the meeting</strong><br />
+                                <p>
+                                    {{ event.UPCOMING_ECOMMENT_MESSAGE }}
+                                </p>
+                            </p>
+
+                            <p>
+                                <strong>Before the meeting</strong><br />
+                                <p>
+                                    <strong>Via email:</strong> <a href="mailto:jacksonm@metro.net">jacksonm@metro.net</a><br />
+                                    <strong>By postal mail:</strong> Board Secretary's Office, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012
+                                </p>
+                            </p>
+
+                            <p>
+                                <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+                                <em>Please make sure to note the meeting name, meeting date, and agenda number or item along with comments submitted by email or postal mail. <strong>Comments via mail must be received by 5pm on the day prior to the meeting.</strong></em>
+                            </p>
+
                         {% endif %}
-                        </p>
                     </div>
                 {% endif %}
             </div>

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -89,10 +89,9 @@
                                 Go to public comment
                             </a>
                         {% else %}
-                            {{ event.UPCOMING_ECOMMENT_MESSAGE }}
                             <strong>Via email:</strong> <a href="mailto:jacksonm@metro.net">jacksonm@metro.net</a><br />
                             <strong>By postal mail:</strong> Board Secretary's Office, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012
-                        </p><br />
+                        </p>
 
                         <p>
                             <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -30,7 +30,7 @@
             </h1>
 
             <div class="row">
-                {% if has_agenda %}
+                {% if has_agenda and not event.has_passed %}
                 <div class="col-sm-7">
                 {% else %}
                 <div class="col-sm-12">
@@ -50,7 +50,7 @@
                         {% endif %}
                     </p>
 
-                    {% if event.show_comment %}
+                    {% if event.is_ongoing %}
                         <p>
                             <strong>You can submit your comments to the Metro Board of Directors during this meeting.</strong> Use the link below to comment on board reports on the agenda.
                         </p>
@@ -78,11 +78,11 @@
                     </p>
                 </div>
 
-                {% if has_agenda %}
+                {% if has_agenda and not event.has_passed %}
                     <div class="col-sm-5">
                         <h4>Submit public comment remotely</h4>
                         <p>
-                            {% if event.show_comment %}
+                            {% if event.is_ongoing %}
                                 <strong>On the web:</strong>
                                 <a href="{{ event.ecomment_url }}" target="_blank">
                                     <i class='fa fa-fw fa-external-link'></i>

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -93,9 +93,6 @@
                     <span class="non-mobile-only"><i class="fa fa-fw fa-group"></i> </span>
                     Upcoming Committee Meetings
                 </h2>
-                <p>
-                    <em>Click the name of each meeting below to view the meeting agenda and submit public comment.</em>
-                </p>
                 {% if upcoming_committee_meetings %}
                     {% if upcoming_committee_meetings %}
                         {% for event in upcoming_committee_meetings %}

--- a/lametro/templates/partials/event_item.html
+++ b/lametro/templates/partials/event_item.html
@@ -1,6 +1,6 @@
 <div class="row">
   <br/>
-  <div class="col-xs-6 col-md-4">
+  <div class="col-xs-4">
     {% if event.status == 'cancelled' %}
       <strike>
     {% endif %}
@@ -23,7 +23,7 @@
     {% endif %}
   </div>
 
-  <div class="col-xs-6 col-md-4">
+  <div class="col-xs-8">
     <p>
       {% if event.status == 'cancelled' %}
         <strike>{{ event.link_html | safe }}</strike>
@@ -31,17 +31,6 @@
         <br/>
       {% else %}
         {{ event.link_html | safe }}<br/>
-      {% endif %}
-    </p>
-  </div>
-
-  <div class="hidden-xs hidden-sm col-md-4 text-center">
-    <p>
-      {% if event.ecomment_url %}
-        <a class="btn btn-salmon btn-sm" href="{{ event.ecomment_url }}" target="_blank">
-          <i class='fa fa-fw fa-external-link'></i>
-          Go to public comment
-        </a>
       {% endif %}
     </p>
   </div>

--- a/lametro/templates/partials/meeting_details_current.html
+++ b/lametro/templates/partials/meeting_details_current.html
@@ -23,17 +23,21 @@
 
                         <div class="text-center">
                             {% if meeting.documents.all %}
-                                <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{ meeting.documents.all|find_agenda_url }}'>
-                                    <i class='fa fa-fw fa-download'></i>
-                                    Get Agenda PDF
-                                </a>
+                                <p>
+                                    <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{ meeting.documents.all|find_agenda_url }}'>
+                                        <i class='fa fa-fw fa-download'></i>
+                                        Get Agenda PDF
+                                    </a>
+                                </p>
                             {% endif %}
 
-                            {% if meeting.ecomment_url %}
-                                <a class="btn btn-salmon" href="{{ event.ecomment_url }}" target="_blank">
-                                    <i class='fa fa-fw fa-external-link'></i>
-                                    Go to public comment
-                                </a>
+                            {% if meeting.is_ongoing %}
+                                <p>
+                                    <a class="btn btn-salmon" href="{{ event.ecomment_url }}" target="_blank">
+                                        <i class='fa fa-fw fa-external-link'></i>
+                                        Go to public comment
+                                    </a>
+                                </p>
                             {% endif %}
                         </div>
                     </p>
@@ -109,12 +113,10 @@
                             </a>
                         {% endif %}
 
-                        {% if current_meeting.first.ecomment_url %}
-                            <a class="btn btn-salmon" href="{{ current_meeting.first.ecomment_url }}" target="_blank" style="margin-top: 10px; margin-left: 5px;">
-                                <i class='fa fa-fw fa-external-link'></i>
-                                Go to public comment
-                            </a>
-                        {% endif %}
+                        <a class="btn btn-salmon" href="{{ current_meeting.first.ecomment_url }}" target="_blank" style="margin-top: 10px; margin-left: 5px;">
+                            <i class='fa fa-fw fa-external-link'></i>
+                            Go to public comment
+                        </a>
                     </p>
                 </div>
             </div>

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -44,17 +44,6 @@
               </div>
             </div>
             {% endif %}
-
-            {% if meeting.ecomment_url %}
-            <div class="row">
-              <div class="col-xs-7">
-                <a class="btn btn-salmon" target="_blank" href="{{ meeting.ecomment_url }}">
-                  <i class="fa fa-fw fa-external-link"></i>
-                  Go to public comment
-                </a>
-              </div>
-            </div>
-            {% endif %}
           </div>
           {% endfor %}
         </div>

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -167,7 +167,7 @@ class LAMetroEventDetail(EventDetailView):
             .filter(related_entities__bill__versions__isnull=False)\
             .annotate(int_order=Cast('order', IntegerField()))\
             .order_by('int_order')
-        
+
         # Find agenda link.
         if event.documents.all():
             for document in event.documents.all():
@@ -198,6 +198,10 @@ class LAMetroEventDetail(EventDetailView):
 
         context['related_board_reports'] = agenda_with_board_reports
         context['base_url'] = PIC_BASE_URL # Give JS access to this variable
+
+        context['has_agenda'] = (context.get('agenda_url') or
+                                 context.get('uploaded_agenda_url') or
+                                 context.get('uploaded_agenda_pdf'))
 
         # Render forms if not a POST request
         if 'url_form' not in context:
@@ -441,7 +445,7 @@ class LACommitteesView(CommitteesView):
             .exclude(person=ceo)\
             .filter(end_date_dt__gt=Now(),
                     organization__classification='committee')
-        
+
         qs = LAMetroOrganization.objects\
                  .filter(classification='committee')\
                  .filter(memberships__in=memberships)\
@@ -452,7 +456,7 @@ class LACommitteesView(CommitteesView):
                                           to_attr='current_members'))
 
         return qs
-    
+
 
 
 class LACommitteeDetailView(CommitteeDetailView):


### PR DESCRIPTION
## Overview

This PR:

- Remove comment links from upcoming board and committee meetings on the homepage
- Updates the current meeting block to display comment links appropriately
- Updates meeting detail pages as follows:
  - **Meetings without agendas:** Displays message that online public comment will be available after agenda is posted

    <img width="1343" alt="Screen Shot 2020-04-10 at 12 28 16 PM" src="https://user-images.githubusercontent.com/12176173/79010191-11280d80-7b27-11ea-868d-6a3c88a0690c.png">

  - **Meetings with agendas:** Displays remote comment options and message that online public comment will be available when the meeting starts

    <img width="1376" alt="Screen Shot 2020-04-10 at 12 33 35 PM" src="https://user-images.githubusercontent.com/12176173/79010420-88f63800-7b27-11ea-865f-fb509f07dc94.png">

  - **Ongoing meetings:** Displays comment link or generic comment link, removes options to comment by mail/email

    <img width="1382" alt="Screen Shot 2020-04-10 at 12 29 41 PM" src="https://user-images.githubusercontent.com/12176173/79010216-200ec000-7b27-11ea-93c2-21017a2e0fb2.png">

  - **Past meetings:** Displays message that online public comment has closed, removes all remote comment options

    <img width="1364" alt="Screen Shot 2020-04-10 at 12 28 28 PM" src="https://user-images.githubusercontent.com/12176173/79010229-269d3780-7b27-11ea-85dd-2a4da62f752d.png">

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

Connects #581, #582, #583, #593.
