### PR TITLE
Include CEO in latest_council_membership

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -187,10 +187,14 @@ class LAMetroPerson(Person, SourcesMixin):
         city_council_memberships = self.memberships.filter(**filter_kwarg)
 
         # Select posts denoting membership, i.e., exclude leadership
-        # posts, like 1st Chair
+        # posts, like 1st Chair.
+        # See: https://github.com/opencivicdata/python-opencivicdata/issues/129
         #
-        # see https://github.com/opencivicdata/python-opencivicdata/issues/129
-        primary_memberships = city_council_memberships.filter(Q(role='Board Member') |
+        # N.b., the CEO is not *technically* a member of the board, but their
+        # role is on the membership side of the membership/leadership dichotomy.
+        # See: https://github.com/datamade/la-metro-councilmatic/issues/351
+        primary_memberships = city_council_memberships.filter(Q(role='Chief Executive Officer') |
+                                                              Q(role='Board Member') |
                                                               Q(role='Nonvoting Board Member'))
 
         if primary_memberships.exists():

--- a/lametro/templates/lametro/committees.html
+++ b/lametro/templates/lametro/committees.html
@@ -64,7 +64,7 @@
 
                 {{ ABOUT_BLURBS.COMMITTEES | safe }}
 
-                <p>The Metro Board of Directors is currently composed of <strong>{{committees_list | length }} Committees</strong>. Committees set policy and discuss matters related to the transit system in Los Angeles County.</p>
+                <p>The Metro Board of Directors is currently composed of <strong>{{ committees | length }} Committees</strong>. Committees set policy and discuss matters related to the transit system in Los Angeles County.</p>
 
                 <p>In addition to these committees, other entities are created by state statute, or by the Board for gathering public input in support of various public purposes beyond routine monthly business. For example, the Service Authority for Freeway Emergencies (SAFE) which oversees:
                     <ol type="a">

--- a/lametro/templates/lametro/person.html
+++ b/lametro/templates/lametro/person.html
@@ -22,9 +22,9 @@
                 <small>
             {% if person.current_council_seat %}
                 {{ person.current_council_seat.role }}
-	    {% else %}
-	        Former {{ person.latest_council_seat.role }}
-	    {% endif %}
+    	    {% else %}
+    	        Former {{ person.latest_council_seat.role }}
+    	    {% endif %}
             <a href="rss/" title="RSS feed for Sponsored Board Actions by {{person.name}}"><i class="fa fa-rss-square" aria-hidden="true"></i></a>
                 </small>
             </h1>

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -73,6 +73,9 @@ def appointment_label(label):
     if 'District 7 Director' in label:
         return label
 
+    elif 'Chief Executive Officer' in label:
+        return label
+
     full_label = label.replace("Appointee of", "Appointee of the")
     label_parts = full_label.split(', ')
 


### PR DESCRIPTION
## Overview

This PR patches a bug that caused the CEO person detail page to break. #FixPhil

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="1176" alt="Screen Shot 2020-04-10 at 2 50 28 PM" src="https://user-images.githubusercontent.com/12176173/79018924-a54fa000-7b3a-11ea-9628-b3cd3ae7b5cf.png">

## Testing Instructions

 * Deploy this to staging, then visit [Phil Washington's page](https://boardagendas.metro.net/person/phil-washington-2daf84e096e2/) and confirm it works as expected.

