### PR TITLE
Use localized datetime to group events by date

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -555,11 +555,6 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
             return self.UPCOMING_ECOMMENT_MESSAGE
 
 
-    @property
-    def local_start_time(self):
-        return timezone.localtime(self.start_time)
-
-
 class EventAgendaItem(EventAgendaItem):
 
     class Meta:

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -555,6 +555,11 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
             return self.UPCOMING_ECOMMENT_MESSAGE
 
 
+    @property
+    def local_start_time(self):
+        return timezone.localtime(self.start_time)
+
+
 class EventAgendaItem(EventAgendaItem):
 
     class Meta:

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -256,7 +256,7 @@ class LAMetroEventsView(EventsView):
         # Did the user set date boundaries?
         start_date_str = self.request.GET.get('from')
         end_date_str   = self.request.GET.get('to')
-        day_grouper    = lambda x: (x.start_time.year, x.start_time.month, x.start_time.day)
+        day_grouper    = lambda x: (x.local_start_time.year, x.local_start_time.month, x.local_start_time.day)
 
         minutes_queryset = EventDocument.objects.filter(note__icontains='minutes')
 
@@ -318,7 +318,7 @@ class LAMetroEventsView(EventsView):
             # Past events
             past_events = LAMetroEvent.objects\
                                       .with_media()\
-                                      .filter(start_time__lt=datetime.datetime.now(app_timezone))\
+                                      .filter(start_time__lt=timezone.now())\
                                       .order_by('-start_time')
 
             past_events = past_events.prefetch_related(Prefetch('documents',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django>=2.2,<2.3
 opencivicdata>=3.1.0
-django-councilmatic[convert_docs]==2.5.5
+django-councilmatic[convert_docs]==2.5.6
 django-debug-toolbar==1.9.1
 sentry-sdk==0.14.2
 gunicorn==19.6.0


### PR DESCRIPTION
## Overview

This PR leverages an upstream change to appropriately group events for display: https://github.com/datamade/django-councilmatic/pull/266. It's necessary because we override the grouping that that PR also fixes.

This addresses #598 because:

> The start time we generate is in UTC. This is fine most places, but we group events for display by date using the year, month, and day from that UTC time. Again, this is fine most of the time, unless an event is scheduled at 5 p.m. or later Pacific, which is midnight the following day in UTC, causing the event to be grouped with the incorrect local date for display.

### Note

The upstream PR should be merged and a release issued before this PR is brought in.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Deploy this to the staging site, and confirm the test event is grouped with the correct date.

Handles #598
