### PR TITLE
Patch member detail view so past member pages render without error

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -209,10 +209,6 @@ class LAMetroPerson(Person, SourcesMixin):
         return ''
 
     @property
-    def latest_council_seat(self):
-        pass
-
-    @property
     def board_office(self):
 
         try:

--- a/lametro/templates/lametro/person.html
+++ b/lametro/templates/lametro/person.html
@@ -23,7 +23,7 @@
             {% if person.current_council_seat %}
                 {{ person.current_council_seat.role }}
     	    {% else %}
-    	        Former {{ person.latest_council_seat.role }}
+    	        Former {{ person.latest_council_membership.role }}
     	    {% endif %}
             <a href="rss/" title="RSS feed for Sponsored Board Actions by {{person.name}}"><i class="fa fa-rss-square" aria-hidden="true"></i></a>
                 </small>

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -531,7 +531,7 @@ class LAPersonDetailView(PersonDetailView):
         context = super().get_context_data(**kwargs)
         person = context['person']
 
-        council_post = person.current_council_seat.post
+        council_post = person.latest_council_membership.post
 
         context['qualifying_post'] = council_post.acting_label
 


### PR DESCRIPTION
## Overview

See title.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Deploy to staging and confirm that [Carrie Bowen](http://lametro-upgrade.datamade.us/person/carrie-bowen-af5a8ab39aad/) renders without error, and the current board member pages show the right thing.

Resolves [this error](https://sentry.io/organizations/datamade/issues/1606609373/?project=2131912).