### PR TITLE
Order board members by role and family name

### DIFF
--- a/lametro/views.py
+++ b/lametro/views.py
@@ -419,7 +419,7 @@ class LABoardMembersView(CouncilMembersView):
         # board membership role to decide display order.
         return sorted(memberships, key=lambda x: (
             display_order[getattr(x.person.board_office, 'role', x.role)],
-            x.person.name
+            x.person.family_name
         ))
 
     def get_context_data(self, *args, **kwargs):


### PR DESCRIPTION
## Overview

This PR orders the board by family name. It depends on https://github.com/opencivicdata/scrapers-us-municipal/pull/321. We should merge and deploy that PR, then run a person scrape on staging and production (or wait for the overnight scrape to run tonight) before merging.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Deploy to staging and confirm board members are ordered by their role (leadership first), and then their last name.

Handles #481.
