### PR TITLE
Add listen links to live event pages

### DIFF
--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -22,11 +22,25 @@
                     <strike>{{event.name}}</strike> <small><span class="label label-stale">Cancelled</span></small>
                 {% else %}
                     {{event.name}}
-                {% endif%}
+                {% endif %}
 
-                {% for media in event.media.all %}
-                    <a class="btn btn-salmon" href="{{ media.links.all.0.url }}" target="_blank"><i class= "fa fa-headphones" aria-hidden="true"></i> {% if media.note == 'Audio (SAP)' %}Ver en Español{% else %}Watch in English{% endif %}</a>
-                {% endfor %}
+                {% if event.is_ongoing %}
+                    <a class="btn btn-salmon" href="{{ event.english_live_media_url }}" target="_blank">
+                        <i class="fa fa-headphones" aria-hidden="true"></i>
+                        Watch in English
+                    </a>
+
+                    {% if event.bilingual %}
+                        <a class="btn btn-salmon" href="{{ event.spanish_live_media_url }}" target="_blank">
+                            <i class="fa fa-headphones" aria-hidden="true"></i>
+                            Ver en Español
+                        </a>
+                    {% endif %}
+                {% else %}
+                    {% for media in event.media.all %}
+                        <a class="btn btn-salmon" href="{{ media.links.all.0.url }}" target="_blank"><i class= "fa fa-headphones" aria-hidden="true"></i> {% if media.note == 'Audio (SAP)' %}Ver en Español{% else %}Watch in English{% endif %}</a>
+                    {% endfor %}
+                {% endif %}
             </h1>
 
             <div class="row">


### PR DESCRIPTION
## Overview

See title.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Deploy to staging and confirm that past events with audio are rendered correctly, and that upcoming events without audio do not display audio links.
 * Coordinate a live event test with Metro to confirm that links are displayed for live meetings.

Handles #597.
