### PR TITLE
Update conditions for displaying bills

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -50,14 +50,21 @@ class LAMetroBillManager(models.Manager):
         N.b., the scrapers contain logic for populating the restrict_view field:
         https://github.com/opencivicdata/scrapers-us-municipal/blob/master/lametro/bills.py
 
-        (2) Does the Bill have a classification of "Board Box"? Then, show it.
+        (2) Does the Bill have a classification of "Board Box" or "Board
+        Correspondence"? Then, show it.
 
         (3) Is the Bill on a published agenda, i.e., an event with the
         status of "passed" or "cancelled"? Then, show it.
 
-        NOTE! A single bill can appear on multiple event agendas.
-        We thus call 'distinct' on the below query, otherwise
-        the queryset would contain duplicate bills.
+        (4) Sometimes motions are made during meetings that were not submitted
+        in advance, i.e., they do not appear on the published agenda. They will
+        be entered as matter history, which we translate to bill actions. Does
+        the bill have any associated actions? Then, show it.
+        https://github.com/datamade/la-metro-councilmatic/issues/477
+
+        NOTE! A single bill can appear on multiple event agendas. We thus call
+        'distinct' on the below query, otherwise the queryset would contain
+        duplicate bills.
 
         WARNING! Be sure to use LAMetroBill, rather than the base Bill class,
         when getting bill querysets. Otherwise restricted view bills
@@ -68,13 +75,15 @@ class LAMetroBillManager(models.Manager):
         qs = qs.exclude(
             extras__restrict_view=True
         ).annotate(board_box=Case(
-            When(extras__local_classification='Board Box', then=True),
+            When(extras__local_classification__in=('Board Box', 'Board Correspondence'), then=True),
             When(classification__contains=['Board Box'], then=True),
+            When(classification__contains=['Board Correspondence'], then=True),
             default=False,
             output_field=models.BooleanField()
         )).filter(Q(eventrelatedentity__agenda_item__event__status='passed') | \
                   Q(eventrelatedentity__agenda_item__event__status='cancelled') | \
-                  Q(board_box=True)
+                  Q(board_box=True) | \
+                  Q(actions__isnull=False)
         ).distinct()
 
         return qs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from opencivicdata.legislative.models import (
     EventRelatedEntity,
     )
 from opencivicdata.core.models import Jurisdiction, Division
-from opencivicdata.legislative.models import EventDocument
+from opencivicdata.legislative.models import EventDocument, BillAction
 from councilmatic_core.models import Bill, Membership
 from lametro.models import LAMetroPerson, LAMetroEvent, LAMetroBill, \
     LAMetroOrganization, LAMetroSubject
@@ -51,6 +51,30 @@ def bill(db, legislative_session):
             return bill
 
     return BillFactory()
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def bill_action(db, bill, metro_organization):
+    class BillActionFactory():
+        def build(self, **kwargs):
+            bill_action_info = {
+                'organization': metro_organization.build(),
+                'description': 'test action',
+                'date': '2019-11-09',
+                'order': 999,
+            }
+
+            bill_action_info.update(kwargs)
+
+            if not bill_action_info.get('bill'):
+                bill_action_info['bill'] = bill.build()
+
+            bill_action = BillAction.objects.create(**bill_action_info)
+
+            return bill_action
+
+    return BillActionFactory()
 
 @pytest.fixture
 @pytest.mark.django_db

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -66,18 +66,23 @@ def test_format_full_text(bill, text, subject):
 
     assert format_full_text(full_text) == subject
 
-@pytest.mark.parametrize('restrict_view,bill_type,event_status,is_public', [
-        (True, 'Board Box', 'passed', False),
-        (False, 'Board Box', 'passed', True),
-        (False, 'Resolution', 'passed', True),
-        (False, 'Resolution', 'cancelled', True),
-        (False, 'Resolution', 'confirmed', False),
+@pytest.mark.parametrize('restrict_view,bill_type,event_status,has_action,is_public', [
+        (True, 'Board Box', 'passed', False, False),  # private bill
+        (False, 'Board Box', 'passed', False, True),  # board box
+        (False, 'Board Correspondence', 'passed', False, True),  # board correspondence
+        (False, 'Resolution', 'passed', False, True),  # on published agenda
+        (False, 'Resolution', 'cancelled', False, True),  # on published agenda
+        (False, 'Resolution', 'confirmed', False, False),  # not on published agenda
+        (False, 'Resolution', 'passed', True, True),  # has matter history
+        (False, 'Test', 'test', False, False),  # not private, but does not meet conditions for display
     ])
 def test_bill_manager(bill,
+                      bill_action,
                       event_related_entity,
                       restrict_view,
                       bill_type,
                       event_status,
+                      has_action,
                       is_public):
     '''
     Tests if the LAMetroBillManager properly filters public and private bills.
@@ -91,6 +96,9 @@ def test_bill_manager(bill,
     }
 
     some_bill = bill.build(**bill_info)
+
+    if has_action:
+        bill_action.build(bill=some_bill)
 
     event_related_entity_info = {
         'bill': some_bill,


### PR DESCRIPTION
## Overview

See title. Namely, this PR:

- Shows bills with the "Board Correspondence" classification.
- Shows bills with any associated actions (matter history).

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Deploy to the staging site and confirm that the example bill, `2016-0950`, is now shown.
 * Tap Metro for help assessing whether the bills displayed are correct, overall.

Handles #477.
