### PR TITLE
Revise upcoming meetings logic

### DIFF
--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -91,7 +91,7 @@
             <div class='col-sm-10 col-sm-offset-1'>
                 <h2>
                     <span class="non-mobile-only"><i class="fa fa-fw fa-group"></i> </span>
-                    Upcoming Committee Meetings
+                    Upcoming Meetings
                 </h2>
                 {% if upcoming_committee_meetings %}
                     {% if upcoming_committee_meetings %}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -265,7 +265,6 @@ def test_upcoming_committee_meetings(event, n_before_board):
     assert upcoming_meetings.count() == expected_count
 
 
-
 def test_upcoming_board_meetings(event):
     one_minute_from_now = LAMetroEvent._time_from_now(minutes=1).strftime('%Y-%m-%d %H:%M')
     forty_days_ago = LAMetroEvent._time_ago(days=40).strftime('%Y-%m-%d %H:%M')


### PR DESCRIPTION
## Overview

This PR updates the upcoming meetings logic to show at least five meetings, up to/including the next board meeting.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Deploy to staging and confirm the right thing shows up.

Handles #511
