### PR TITLE
Revert revised bill filter, pending Metro guidance

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from opencivicdata.legislative.models import (
     EventRelatedEntity,
     )
 from opencivicdata.core.models import Jurisdiction, Division
-from opencivicdata.legislative.models import EventDocument, BillAction
+from opencivicdata.legislative.models import EventDocument
 from councilmatic_core.models import Bill, Membership
 from lametro.models import LAMetroPerson, LAMetroEvent, LAMetroBill, \
     LAMetroOrganization, LAMetroSubject
@@ -51,30 +51,6 @@ def bill(db, legislative_session):
             return bill
 
     return BillFactory()
-
-
-@pytest.fixture
-@pytest.mark.django_db
-def bill_action(db, bill, metro_organization):
-    class BillActionFactory():
-        def build(self, **kwargs):
-            bill_action_info = {
-                'organization': metro_organization.build(),
-                'description': 'test action',
-                'date': '2019-11-09',
-                'order': 999,
-            }
-
-            bill_action_info.update(kwargs)
-
-            if not bill_action_info.get('bill'):
-                bill_action_info['bill'] = bill.build()
-
-            bill_action = BillAction.objects.create(**bill_action_info)
-
-            return bill_action
-
-    return BillActionFactory()
 
 @pytest.fixture
 @pytest.mark.django_db

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -66,23 +66,18 @@ def test_format_full_text(bill, text, subject):
 
     assert format_full_text(full_text) == subject
 
-@pytest.mark.parametrize('restrict_view,bill_type,event_status,has_action,is_public', [
-        (True, 'Board Box', 'passed', False, False),  # private bill
-        (False, 'Board Box', 'passed', False, True),  # board box
-        (False, 'Board Correspondence', 'passed', False, True),  # board correspondence
-        (False, 'Resolution', 'passed', False, True),  # on published agenda
-        (False, 'Resolution', 'cancelled', False, True),  # on published agenda
-        (False, 'Resolution', 'confirmed', False, False),  # not on published agenda
-        (False, 'Resolution', 'passed', True, True),  # has matter history
-        (False, 'Test', 'test', False, False),  # not private, but does not meet conditions for display
+@pytest.mark.parametrize('restrict_view,bill_type,event_status,is_public', [
+        (True, 'Board Box', 'passed', False),
+        (False, 'Board Box', 'passed', True),
+        (False, 'Resolution', 'passed', True),
+        (False, 'Resolution', 'cancelled', True),
+        (False, 'Resolution', 'confirmed', False),
     ])
 def test_bill_manager(bill,
-                      bill_action,
                       event_related_entity,
                       restrict_view,
                       bill_type,
                       event_status,
-                      has_action,
                       is_public):
     '''
     Tests if the LAMetroBillManager properly filters public and private bills.
@@ -96,9 +91,6 @@ def test_bill_manager(bill,
     }
 
     some_bill = bill.build(**bill_info)
-
-    if has_action:
-        bill_action.build(bill=some_bill)
 
     event_related_entity_info = {
         'bill': some_bill,


### PR DESCRIPTION
## Overview

See title. Revising the bill filter (#477) revealed some strange looking board reports. Metro is investigating whether we need to make further revisions to the bill display logic. In the meantime, pull the changes off master.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

Will open a separate branch/PR reverting this revert, for development.
