### PR TITLE
Remove staging crontask

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Did everything work as expected? Great - now onto the production site.
 
 Make sure your changes are deployed to the production server (i.e. you've cut a release with your changes).
 
-1. Look at the times cron tasks are run (specified in [`scripts/lametro-crontasks`](https://github.com/datamade/la-metro-councilmatic/blob/master/scripts/lametro-crontasks)), and plan to rebuild the index inbetween those times. Rebuilding the index will take a few minutes, so plan accordingly.
+1. Look at the times scheduled tasks are run (specified in [the `la-metro-dashboard` repo](https://github.com/datamade/la-metro-dashboard/tree/master/dags)), and plan to rebuild the index inbetween those times. Rebuilding the index will take a few minutes, so plan accordingly.
 
 2. As above: shell into the server, go to the `lametro` repo, then remove and rebuild the Solr container.
     ```bash

--- a/scripts/lametro-staging-crontasks
+++ b/scripts/lametro-staging-crontasks
@@ -1,8 +1,0 @@
-# /etc/cron.d/lametro-staging-crontasks
-APPDIR=/home/datamade/lametro-staging
-PYTHONDIR=/home/datamade/.virtualenvs/lametro-staging/bin/python
-
-# TODO: Remove this after the cut over.
-0 1 * * * datamade cd $APPDIR && $PYTHONDIR manage.py refresh_guid >> /var/log/councilmatic/lametro-staging-refreshguid.log 2&1
-
-0 8 * * * datamade /usr/bin/flock -n /tmp/lametro_staging_dataload.lock -c 'cd $APPDIR && $PYTHONDIR manage.py compile_pdfs --db_only >> /var/log/councilmatic/lametro-staging-compilepdfs.log 2>&1 && $PYTHONDIR manage.py convert_attachment_text >> /var/log/councilmatic/lametro-staging-convertattachments.log 2>&1 && $PYTHONDIR manage.py update_index --batch-size=100 >> /var/log/councilmatic/lametro-staging-updateindex.log 2>&1 && $PYTHONDIR manage.py data_integrity >> /var/log/councilmatic/lametro-staging-integrity.log 2>&1'


### PR DESCRIPTION
## Overview

Remove staging crontask so that processing can be done by https://github.com/datamade/la-metro-dashboard/.

Connects https://github.com/datamade/la-metro-dashboard/pull/24, https://github.com/datamade/scrapers-us-municipal/pull/52.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

In order to test this change, I manually removed the staging crontask as well.

## Testing Instructions

- Confirm the diff makes sense
- Anything else that would make sense to test?