### PR TITLE
Only hyperlink board members, patch headshot_url property

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -261,7 +261,7 @@ class LAMetroPerson(Person, SourcesMixin):
         if self.slug in settings.MANUAL_HEADSHOTS:
             return '/static/images/' + settings.MANUAL_HEADSHOTS[self.slug]['image']
         elif self.headshot:
-            return '/static/images/' + self.id + ".jpg"
+            return self.headshot.url
         else:
             return '/static/images/headshot_placeholder.png'
 

--- a/lametro/templates/lametro/committee.html
+++ b/lametro/templates/lametro/committee.html
@@ -69,7 +69,11 @@
                                     </div>
                                 </td>
                                 <td>
-                                    <a href="{% url 'lametro:person' membership.person.slug %}">{{ membership.person.name }}</a>
+                                    {% if membership.person.latest_council_membership %}
+                                        <a href="{% url 'lametro:person' membership.person.slug %}">{{ membership.person.name }}</a>
+                                    {% else %}
+                                        {{ membership.person.name }}
+                                    {% endif %}
                                 </td>
                                 <td>
                                     {{ membership.extras | clean_membership_extras }} {{ membership.person.latest_council_membership.post.label | format_label }}


### PR DESCRIPTION
## Overview

See title. 

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Run the app locally.
 * Import the latest memberships: `docker-compose run --rm scrapers pupa update lametro people --rpm=0`
 * Navigate to `Committees` > `Measure M Taxpayer Oversight Committee`. Confirm that the committee member names are displayed as plain text rather than hyperlinks.

Handles #626
