### PR TITLE
Handle private bills during event packet build

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -740,8 +740,15 @@ class EventPacket(Packet):
 
         for item in agenda_items:
             for entity in item.related_entities.filter(bill__isnull=False):
-                bill_packet = BillPacket(bill=entity.bill)
-                related.extend(bill_packet.related_files)
+                try:
+                    related_bill = entity.bill
+                except LAMetroBill.DoesNotExist:
+                    # If this exception occurs, the related bill is private.
+                    # Skip it.
+                    continue
+                else:
+                    bill_packet = BillPacket(bill=related_bill)
+                    related.extend(bill_packet.related_files)
 
         return related
 

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -744,12 +744,12 @@ class EventPacket(Packet):
                     related_bill = entity.bill
                 except LAMetroBill.DoesNotExist:
                     # We configure event agenda items to return LAMetroBill
-                    # objects. Sometimes, agendas items concern bills that do
+                    # objects. Sometimes, agenda items concern bills that do
                     # not meet criteria for display, e.g., the bill is private
                     # or it does not appear on a published agenda. (See the
                     # LAMetroBill manager for an exhaustive list of display
                     # criteria.) In this case, trying to access the bill via
-                    # the event related entity will raise this exception. Skip
+                    # the event agenda item will raise this exception. Skip
                     # adding those documents to the event packet.
                     continue
                 else:

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -743,8 +743,14 @@ class EventPacket(Packet):
                 try:
                     related_bill = entity.bill
                 except LAMetroBill.DoesNotExist:
-                    # If this exception occurs, the related bill is private.
-                    # Skip it.
+                    # We configure event agenda items to return LAMetroBill
+                    # objects. Sometimes, agendas items concern bills that do
+                    # not meet criteria for display, e.g., the bill is private
+                    # or it does not appear on a published agenda. (See the
+                    # LAMetroBill manager for an exhaustive list of display
+                    # criteria.) In this case, trying to access the bill via
+                    # the event related entity will raise this exception. Skip
+                    # adding those documents to the event packet.
                     continue
                 else:
                     bill_packet = BillPacket(bill=related_bill)


### PR DESCRIPTION
## Overview

Sometimes event agenda items can be associated with matters that are private (or otherwise do not meet criteria for display on the board agendas site). When this happens, it causes event packet building to fail! See: https://github.com/datamade/la-metro-dashboard/issues/46. This PR handles that exception. 

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

We run the risk of this happening everywhere we access bills via a foreign key relationship that has been overridden to use `LAMetroBill`. (IIRC, there are 3-4 places, including this one.) I'll open a separate issue to audit that, since this patch is time sensitive.

FWIW, I don't see a solution to handle this further upstream, e.g., [in `django-proxy-overrides`](https://github.com/datamade/django-proxy-overrides/blob/master/proxy_overrides/base.py), though I'd be happy to discuss, if one seems obvious to you, @fgregg!

## Testing Instructions

 * Merge this PR, and wait for the latest `staging` tag to build in Dockerhub.
 * Trigger the `hourly_processing` DAG on the dashboard and confirm the `compile_pdfs` task succeeds.

Handles https://github.com/datamade/la-metro-dashboard/issues/46
