### PR TITLE
Increase Solr heap size in production

### DIFF
--- a/docker-compose.deployment.yml
+++ b/docker-compose.deployment.yml
@@ -10,7 +10,8 @@ services:
     ports:
       - '127.0.0.1:8985:8983'
     environment:
-      SOLR_LOG_LEVEL: ERROR
+      - SOLR_LOG_LEVEL=ERROR
+      - SOLR_HEAP=2g
     restart: on-failure
   solr-staging:
     image: solr:7.5

--- a/docker-compose.deployment.yml
+++ b/docker-compose.deployment.yml
@@ -11,7 +11,7 @@ services:
       - '127.0.0.1:8985:8983'
     environment:
       - SOLR_LOG_LEVEL=ERROR
-      - SOLR_HEAP=2g
+      - SOLR_HEAP=1g
     restart: on-failure
   solr-staging:
     image: solr:7.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,8 @@ services:
     ports:
       - 8986:8983
     environment:
-      SOLR_LOG_LEVEL: INFO
+      - SOLR_LOG_LEVEL=INFO
+      - SOLR_JAVA_MEM="-Xms10g -Xmx10g"
     restart: on-failure
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,6 @@ services:
       - 8986:8983
     environment:
       - SOLR_LOG_LEVEL=INFO
-      - SOLR_JAVA_MEM="-Xms10g -Xmx10g"
     restart: on-failure
 
 volumes:


### PR DESCRIPTION
## Overview

See title. There is a detailed discussion of why I did this in #538.

For reference, the Metro server is a t2 large EC2 instance:

<img width="852" alt="Screen Shot 2020-08-12 at 3 28 49 PM" src="https://user-images.githubusercontent.com/12176173/90064546-8c095c80-dcb0-11ea-9651-3e737ccd8725.png">

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Start the production Solr instance locally: `docker-compose -f docker-compose.deployment.yml up solr-production`
 * Navigate to http://localhost:8985/solr/ and confirm the JVM Memory is 1 GB (or in that neighborhood – sometimes it's a little less, e.g., mine is 981 MB).

Handles #538