### PR TITLE
Properly escape selected facets in search.html

### DIFF
--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -311,17 +311,12 @@
     });
 
     var topicFacets = {{ topic_facets|safe }};
-    var selectedFacets = {{ request.GET|get_list:"selected_facets"|safe }};
+    var selectedFacets = JSON.parse($('#selected-facets').text());
 
-    var facetTerms = selectedFacets.reduce(function (terms, facet) {
-        var splitFacet = facet.split(':');
-        var facetName = splitFacet[0];
-        var facetValue = splitFacet[1];
-
-        topicFacets.includes(facetName) ? terms.push(facetValue) : $.noop();
-
-        return terms;
-    }, []);
+    var facetTerms = [];
+    $.each(selectedFacets, function(facetName, facetValue) {
+        topicFacets.includes(facetName) ? facetTerms.push(facetValue) : $.noop();
+    })
 
     showRelatedTerms(queryTerms.concat(facetTerms));
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django>=2.2,<2.3
 opencivicdata>=3.1.0
-django-councilmatic[convert_docs]==2.5.8
+https://github.com/datamade/django-councilmatic/zipball/hotfix/jfc/2.5-escape-selected-facets
 django-debug-toolbar==1.9.1
 sentry-sdk==0.14.2
 gunicorn==19.6.0


### PR DESCRIPTION
## Overview

This PR updates `search/search.html` to retrieve selected facets from a `<script>` element produced by [`json_script`](https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#json-script).

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Notes

I've pinned `django-councilmatic` to my feature branch for the purposes of testing https://github.com/datamade/django-councilmatic/pull/271. Before pulling this in, I'll adjust `requirements.txt` to reset the version of `django-councilmatic` to the version we deploy to fix https://github.com/datamade/django-councilmatic/issues/270.

## Testing Instructions

* Rebuild containers and start dev server: `docker-compose up --build app`
* Navigate to http://localhost:8001/search/?q=&selected_facets=sponsorships_exact%3A%3Cscript%3Ealert(%22Inserted%20Javascript%22)%3C/script%3E
* Confirm that you do not see a JavaScript alert

Connects https://github.com/datamade/django-councilmatic/issues/270.
