### PR TITLE
Remove RSS link on board report detail page

### DIFF
--- a/lametro/templates/lametro/legislation.html
+++ b/lametro/templates/lametro/legislation.html
@@ -24,7 +24,6 @@
                     {% if legislation.inferred_status %}
                         {{ legislation.inferred_status | inferred_status_label | safe }}
                     {% endif %}
-                    <a href="rss/" title="RSS feed for Legislation {{legislation.friendly_name}}" target="_blank"><i class="fa fa-rss-square" aria-hidden="true"></i></a>
 
                 </h1>
 


### PR DESCRIPTION
## Overview

See title.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Run the application as described in the README.
 * If you don't have any data in your database, run a scrape: `docker-compose run --rm scrapers` (This may take a while.)
 * Populate your search index: `docker-compose run --rm app python manage.py update_index`
 * Navigate to the search page and click the first result: https://localhost:8001/search
 * On the board report page, confirm that you do not see a pink / red RSS link at the top of the page.

Related to #51.
