### PR TITLE
Upgrade to django-councilmatic 2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django>=2.2,<2.3
 opencivicdata>=3.1.0
-django-councilmatic[convert_docs]==2.5.9
+django-councilmatic[convert_docs]==2.6.0
 django-debug-toolbar==1.9.1
 sentry-sdk==0.14.2
 gunicorn==19.6.0

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -134,4 +134,4 @@ def test_last_action_date_has_already_occurred(bill, event):
     last_action_date = some_bill.councilmatic_bill.get_last_action_date()
 
     # Assert the last action matches the event that has already occurred.
-    assert last_action_date.date() == two_weeks_ago.date()
+    assert last_action_date == two_weeks_ago.date()


### PR DESCRIPTION
## Overview

This PR upgrades `django-councilmatic` to capture https://github.com/datamade/django-councilmatic/pull/272, which handles #638. It also updates one test affected by that change.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

N/A – just an FYI! (I'll cruise the staging site after this deploys to double check that the fix addresses #638 and that nothing is broken.)

Handles #638.
