### PR TITLE
Add dial-in instructions to event pages

### DIFF
--- a/councilmatic/settings_jurisdiction.py
+++ b/councilmatic/settings_jurisdiction.py
@@ -306,3 +306,6 @@ EXTRA_TITLES = {
 }
 
 USING_NOTIFICATIONS = False
+
+# Set this to True to show online public comment links while meetings are ongoing
+USING_ECOMMENT = False

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -531,6 +531,20 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
 
 
     @property
+    def is_upcoming(self):
+        day_before = (
+            self.start_time - timedelta(days=1)
+        ).date()
+
+        evening_before = datetime(
+            day_before.year, day_before.month, day_before.day,
+            17, 0, tzinfo=pytz.timezone(settings.TIME_ZONE)
+        )
+
+        return timezone.now() >= evening_before and not self.has_passed
+
+
+    @property
     def is_ongoing(self):
         if not hasattr(self, '_is_ongoing'):
             self._is_ongoing = self in type(self).current_meeting()

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -545,7 +545,9 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
             17, 0, tzinfo=pytz.timezone(settings.TIME_ZONE)
         )
 
-        return timezone.now() >= evening_before and not any([self.is_ongoing, self.has_passed])
+        return self.status != 'cancelled' \
+            and timezone.now() >= evening_before \
+            and not any([self.is_ongoing, self.has_passed])
 
 
     @property

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -532,6 +532,10 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
 
     @property
     def is_upcoming(self):
+        '''
+        An event is upcoming starting at 5 p.m. the evening before its start
+        time and ending once the meeting begins.
+        '''
         day_before = (
             self.start_time - timedelta(days=1)
         ).date()
@@ -541,7 +545,7 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
             17, 0, tzinfo=pytz.timezone(settings.TIME_ZONE)
         )
 
-        return timezone.now() >= evening_before and not self.has_passed
+        return timezone.now() >= evening_before and not any([self.is_ongoing, self.has_passed])
 
 
     @property

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -102,8 +102,9 @@
                             <strong>During the meeting</strong>
                         </p>
 
+                        <strong>By phone:</strong>
+
                         {% if event.is_upcoming or event.is_ongoing %}
-                            <strong>By phone:</strong>
 
                             <p>You may join the public comment participation call 5 minutes prior to the start of the meeting.</p>
 

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -94,6 +94,25 @@
 
                 {% if has_agenda and not event.has_passed %}
                     <div class="col-sm-5">
+                        {% if event.is_ongoing %}
+                            <h4>Participant Instructions</h4>
+
+                            <p>The conference begins at {{event.start_time | date:"g:i a"}} Pacific Time on {{event.start_time | date:"F n, Y"}}; you may join the conference 5 minutes prior.</p>
+
+                            <p>
+                                <strong>Dial-in:</strong> 888-251-2949 or 215-861-0694<br/>
+                                <strong>English Access Code:</strong> 8231160#<br/>
+                                <strong>Spanish Access Code:</strong> 4544724#
+                            </p>
+
+                            <p>
+                                Need an international dial-in number? <a href="#" target="_blank">Please click here.</a>
+
+                            <p>
+                                Need assistance with your audio? Please dial 888-796-6118.
+                            </p><br />
+                        {% endif %}
+
                         <h4>Submit public comment remotely</h4>
                         {% if event.is_ongoing %}
 

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -96,19 +96,21 @@
 
                 {% if has_agenda and not event.has_passed %}
                     <div class="col-sm-5">
-                        {% if event.is_ongoing %}
-                            <h4>Participant Instructions</h4>
+                        <h4>Submit public comment remotely</h4>
 
-                            <p>The conference begins at {{event.start_time | date:"g:i a"}} Pacific Time on {{event.start_time | date:"F j, Y"}}; you may join the conference 5 minutes prior.</p>
+                        <p>
+                            <strong>During the meeting</strong>
+                        </p>
+
+                        {% if event.is_upcoming or event.is_ongoing %}
+                            <strong>By phone:</strong>
+
+                            <p>You may join the public comment participation call 5 minutes prior to the start of the meeting.</p>
 
                             <p>
                                 <strong>Dial-in:</strong> 888-251-2949 or 215-861-0694<br/>
                                 <strong>English Access Code:</strong> 8231160#<br/>
                                 <strong>Spanish Access Code:</strong> 4544724#
-                            </p>
-
-                            <p>
-                                Need an international dial-in number? <a href="https://www.teleconference.att.com/servlet/glbAccess?process=0&accessCode=8231160&accessNumber=8882512949&brand=att" target="_blank"><i class='fa fa-fw fa-external-link'></i> Please click here.</a>
                             </p>
 
                             <p>
@@ -122,9 +124,7 @@
 
                             <br />
 
-                            {% if USING_ECOMMENT %}
-                                <h4>Submit public comment remotely</h4>
-
+                            {% if event.is_ongoing and USING_ECOMMENT %}
                                 <p>
                                     <strong>On the web:</strong>
                                     <a href="{{ event.ecomment_url }}" target="_blank">
@@ -134,15 +134,13 @@
                                 </p>
                             {% endif %}
                         {% else %}
-                            <h4>Submit public comment remotely</h4>
+                            <p>
+                                Dial-in information to submit public comment by phone will become available on this page the evening before the meeting.
+                            </p>
 
                             {% if USING_ECOMMENT %}
                                 <p>
-                                    <strong>During the meeting</strong><br />
-
-                                    <p>
-                                        {{ event.UPCOMING_ECOMMENT_MESSAGE }}
-                                    </p>
+                                    {{ event.UPCOMING_ECOMMENT_MESSAGE }}
                                 </p>
                             {% endif %}
 

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -108,16 +108,22 @@
                             </p>
 
                             <p>
-                                Need an international dial-in number? <a href="#" target="_blank">Please click here.</a>
+                                Need an international dial-in number? <a href="https://www.teleconference.att.com/servlet/glbAccess?process=0&accessCode=8231160&accessNumber=8882512949&brand=att" target="_blank"><i class='fa fa-fw fa-external-link'></i> Please click here.</a>
+                            </p>
 
                             <p>
                                 Need assistance with your audio? Please dial 888-796-6118.
-                            </p><br />
-                        {% endif %}
+                            </p>
 
-                        {% if USING_ECOMMENT %}
-                            <h4>Submit public comment remotely</h4>
-                            {% if event.is_ongoing %}
+                            <p>
+                                <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+                                <em>When you call in to comment, you will be able to hear the live stream of the meeting while you wait to comment. <strong>If you are also listening to the meeting on another device, please lower the volume on the second device to avoid feedback and ensure you can be heard clearly.</strong></em>
+                            </p>
+
+                            <br />
+
+                            {% if USING_ECOMMENT %}
+                                <h4>Submit public comment remotely</h4>
 
                                 <p>
                                     <strong>On the web:</strong>
@@ -126,30 +132,33 @@
                                         Go to public comment
                                     </a>
                                 </p>
+                            {% endif %}
+                        {% else %}
+                            <h4>Submit public comment remotely</h4>
 
-                            {% else %}
-
+                            {% if USING_ECOMMENT %}
                                 <p>
                                     <strong>During the meeting</strong><br />
+
                                     <p>
                                         {{ event.UPCOMING_ECOMMENT_MESSAGE }}
                                     </p>
                                 </p>
-
-                                <p>
-                                    <strong>Before the meeting</strong><br />
-                                    <p>
-                                        <strong>Via email:</strong> <a href="mailto:jacksonm@metro.net">jacksonm@metro.net</a><br />
-                                        <strong>By postal mail:</strong> Board Secretary's Office, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012
-                                    </p>
-                                </p>
-
-                                <p>
-                                    <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-                                    <em>Please make sure to note the meeting name, meeting date, and agenda number or item along with comments submitted by email or postal mail. <strong>Comments via mail must be received by 5pm on the day prior to the meeting.</strong></em>
-                                </p>
-
                             {% endif %}
+
+                            <p>
+                                <strong>Before the meeting</strong><br />
+
+                                <p>
+                                    <strong>Via email:</strong> <a href="mailto:jacksonm@metro.net">jacksonm@metro.net</a><br />
+                                    <strong>By postal mail:</strong> Board Secretary's Office, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012
+                                </p>
+                            </p>
+
+                            <p>
+                                <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+                                <em>Please make sure to note the meeting name, meeting date, and agenda number or item along with comments submitted by email or postal mail. <strong>Comments via mail must be received by 5pm on the day prior to the meeting.</strong></em>
+                            </p>
                         {% endif %}
                     </div>
                 {% endif %}

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -64,19 +64,21 @@
                         {% endif %}
                     </p>
 
-                    {% if event.is_ongoing %}
-                        <p>
-                            <strong>You can submit your comments to the Metro Board of Directors during this meeting.</strong> Use the link below to comment on board reports on the agenda.
-                        </p>
+                    {% if USING_ECOMMENT %}
+                        {% if event.is_ongoing %}
+                            <p>
+                                <strong>You can submit your comments to the Metro Board of Directors during this meeting.</strong> Use the link below to comment on board reports on the agenda.
+                            </p>
 
-                        <p>
-                            <a class="btn btn-salmon" href="{{ event.ecomment_url }}" target="_blank">
-                                <i class='fa fa-fw fa-external-link'></i>
-                                Go to public comment
-                            </a>
-                        </p>
-                    {% elif event.ecomment_message %}
-                        <p>{{ event.ecomment_message|safe }}</p>
+                            <p>
+                                <a class="btn btn-salmon" href="{{ event.ecomment_url }}" target="_blank">
+                                    <i class='fa fa-fw fa-external-link'></i>
+                                    Go to public comment
+                                </a>
+                            </p>
+                        {% elif event.ecomment_message %}
+                            <p>{{ event.ecomment_message|safe }}</p>
+                        {% endif %}
                     {% endif %}
 
                     <p class="small">
@@ -113,39 +115,41 @@
                             </p><br />
                         {% endif %}
 
-                        <h4>Submit public comment remotely</h4>
-                        {% if event.is_ongoing %}
+                        {% if USING_ECOMMENT %}
+                            <h4>Submit public comment remotely</h4>
+                            {% if event.is_ongoing %}
 
-                            <p>
-                                <strong>On the web:</strong>
-                                <a href="{{ event.ecomment_url }}" target="_blank">
-                                    <i class='fa fa-fw fa-external-link'></i>
-                                    Go to public comment
-                                </a>
-                            </p>
-
-                        {% else %}
-
-                            <p>
-                                <strong>During the meeting</strong><br />
                                 <p>
-                                    {{ event.UPCOMING_ECOMMENT_MESSAGE }}
+                                    <strong>On the web:</strong>
+                                    <a href="{{ event.ecomment_url }}" target="_blank">
+                                        <i class='fa fa-fw fa-external-link'></i>
+                                        Go to public comment
+                                    </a>
                                 </p>
-                            </p>
 
-                            <p>
-                                <strong>Before the meeting</strong><br />
+                            {% else %}
+
                                 <p>
-                                    <strong>Via email:</strong> <a href="mailto:jacksonm@metro.net">jacksonm@metro.net</a><br />
-                                    <strong>By postal mail:</strong> Board Secretary's Office, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012
+                                    <strong>During the meeting</strong><br />
+                                    <p>
+                                        {{ event.UPCOMING_ECOMMENT_MESSAGE }}
+                                    </p>
                                 </p>
-                            </p>
 
-                            <p>
-                                <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-                                <em>Please make sure to note the meeting name, meeting date, and agenda number or item along with comments submitted by email or postal mail. <strong>Comments via mail must be received by 5pm on the day prior to the meeting.</strong></em>
-                            </p>
+                                <p>
+                                    <strong>Before the meeting</strong><br />
+                                    <p>
+                                        <strong>Via email:</strong> <a href="mailto:jacksonm@metro.net">jacksonm@metro.net</a><br />
+                                        <strong>By postal mail:</strong> Board Secretary's Office, One Gateway Plaza, MS: 99-3-1, Los Angeles, CA 90012
+                                    </p>
+                                </p>
 
+                                <p>
+                                    <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+                                    <em>Please make sure to note the meeting name, meeting date, and agenda number or item along with comments submitted by email or postal mail. <strong>Comments via mail must be received by 5pm on the day prior to the meeting.</strong></em>
+                                </p>
+
+                            {% endif %}
                         {% endif %}
                     </div>
                 {% endif %}

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -97,7 +97,7 @@
                         {% if event.is_ongoing %}
                             <h4>Participant Instructions</h4>
 
-                            <p>The conference begins at {{event.start_time | date:"g:i a"}} Pacific Time on {{event.start_time | date:"F n, Y"}}; you may join the conference 5 minutes prior.</p>
+                            <p>The conference begins at {{event.start_time | date:"g:i a"}} Pacific Time on {{event.start_time | date:"F j, Y"}}; you may join the conference 5 minutes prior.</p>
 
                             <p>
                                 <strong>Dial-in:</strong> 888-251-2949 or 215-861-0694<br/>

--- a/lametro/templates/partials/meeting_details_current.html
+++ b/lametro/templates/partials/meeting_details_current.html
@@ -31,7 +31,7 @@
                                 </p>
                             {% endif %}
 
-                            {% if meeting.is_ongoing %}
+                            {% if meeting.is_ongoing and USING_ECOMMENT %}
                                 <p>
                                     <a class="btn btn-salmon" href="{{ event.ecomment_url }}" target="_blank">
                                         <i class='fa fa-fw fa-external-link'></i>
@@ -113,10 +113,12 @@
                             </a>
                         {% endif %}
 
-                        <a class="btn btn-salmon" href="{{ current_meeting.first.ecomment_url }}" target="_blank" style="margin-top: 10px; margin-left: 5px;">
-                            <i class='fa fa-fw fa-external-link'></i>
-                            Go to public comment
-                        </a>
+                        {% if USING_ECOMMENT %}
+                            <a class="btn btn-salmon" href="{{ current_meeting.first.ecomment_url }}" target="_blank" style="margin-top: 10px; margin-left: 5px;">
+                                <i class='fa fa-fw fa-external-link'></i>
+                                Go to public comment
+                            </a>
+                        {% endif %}
                     </p>
                 </div>
             </div>

--- a/lametro/templates/partials/meeting_details_next.html
+++ b/lametro/templates/partials/meeting_details_next.html
@@ -63,7 +63,7 @@
         </p>
         {% endif %}
 
-        {% if not upcoming_board_meetings|all_have_extra:'ecomment' %}
+        {% if not upcoming_board_meetings|all_have_extra:'ecomment' and USING_ECOMMENT %}
         <p class="small">
           <em>{{ upcoming_board_meetings.first.UPCOMING_ECOMMENT_MESSAGE|safe }}</em>
         </p>

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -73,6 +73,7 @@ class LAMetroIndexView(IndexView):
         extra['upcoming_board_meetings'] = self.event_model.upcoming_board_meetings()[:2]
         extra['current_meeting'] = self.event_model.current_meeting()
         extra['bilingual'] = bool([e for e in extra['current_meeting'] if e.bilingual])
+        extra['USING_ECOMMENT'] = settings.USING_ECOMMENT
 
         return extra
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -207,6 +207,9 @@ class LAMetroEventDetail(EventDetailView):
         if 'pdf_form' not in context:
             context['pdf_form'] = AgendaPdfForm()
 
+
+        context['USING_ECOMMENT'] = settings.USING_ECOMMENT
+
         return context
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -294,7 +294,7 @@ def test_event_is_upcoming(event, mocker):
     _event = event.build(start_date=in_an_hour.strftime('%Y-%m-%d %H:%M'))
 
     # Get event from queryset so it has the start_time annotation from the manager
-    upcoming_event = LAMetroEvent.objects.get(id=_event.id)
+    test_event = LAMetroEvent.objects.get(id=_event.id)
 
     # Create three timestamps to test upcoming at three points in time...
     yesterday = (in_an_hour - timedelta(days=1)).date()
@@ -324,12 +324,19 @@ def test_event_is_upcoming(event, mocker):
 
     mock_timezone.return_value = yesterday_afternoon
 
-    assert not upcoming_event.is_upcoming
+    assert not test_event.is_upcoming
 
     mock_timezone.return_value = yesterday_evening
 
-    assert upcoming_event.is_upcoming
+    assert test_event.is_upcoming
+
+    test_event.status = 'cancelled'
+    test_event.save()
+
+    assert not test_event.is_upcoming
+
+    test_event.status = 'confirmed'
 
     mock_timezone.return_value = tomorrow_morning
 
-    assert not upcoming_event.is_upcoming
+    assert not test_event.is_upcoming

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -330,12 +330,14 @@ def test_event_is_upcoming(event, mocker):
 
     assert test_event.is_upcoming
 
+    # Test that cancelled meetings are not upcoming, even during the window
     test_event.status = 'cancelled'
     test_event.save()
 
     assert not test_event.is_upcoming
 
     test_event.status = 'confirmed'
+    test_event.save()
 
     mock_timezone.return_value = tomorrow_morning
 


### PR DESCRIPTION
## Overview

This PR:

- Adds instructions for submitting public comment by phone to event pages
- Adds a setting to toggle public comment on and off across the site, and sets it to off
- Adds an `is_upcoming` property to `LAMetroEvent` that, for events that have not been cancelled, returns True between 5 p.m. the evening before the meeting until the meeting begins.
- Conditionally displays public comment instructions depending on the public comment settings and whether the meeting is upcoming, ongoing, or passed.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

Agenda posted

![Screen Shot 2020-09-22 at 9 08 02 AM](https://user-images.githubusercontent.com/12176173/93893476-48dcd900-fcb3-11ea-9792-183760de79aa.png)

Evening before meeting

![Screen Shot 2020-09-22 at 9 08 22 AM](https://user-images.githubusercontent.com/12176173/93893493-4c706000-fcb3-11ea-8f7c-da143613379d.png)

During meeting

![Screen Shot 2020-09-22 at 9 02 54 AM](https://user-images.githubusercontent.com/12176173/93892805-8ab94f80-fcb2-11ea-9d2b-510a8d4b9528.png)

After meeting

![Screen Shot 2020-09-22 at 9 03 12 AM](https://user-images.githubusercontent.com/12176173/93892812-8e4cd680-fcb2-11ea-9b6d-faf660c10103.png)

Handles #652
