### PR TITLE
Re-enable board report listing on board member detail page

### DIFF
--- a/lametro/templates/lametro/person.html
+++ b/lametro/templates/lametro/person.html
@@ -106,8 +106,8 @@
                         </span>
                     </a>
                 </li>
-                <li role="presentation" {% if request.GET.view == 'bills' %}class='active' {% endif %}>
-                    <a href="/person/{{person.slug}}/?view=bills">
+                <li role="presentation" {% if request.GET.view == 'board-reports' %}class='active' {% endif %}>
+                    <a href="/person/{{person.slug}}/?view=board-reports">
                         <span class="small-pill">
                             <i class='fa fa-fw fa-files-o'></i>
                             Board Reports
@@ -116,25 +116,14 @@
                 </li>
             </ul>
 
-            {% if request.GET.view == 'bills' %}
-                <h3>
-                    <i class='fa fa-fw fa-files-o'></i>
-                    Board Reports
-                </h3>
-                <p>Board reports considered by committees of which {{person.name}} is a member</p><br/>
-
-                {% for legislation in sponsored_legislation %}
-
-                    {% include "partials/legislation_item.html" %}
-
-                {% endfor %}
-
-            {% elif request.GET.view == 'committees' or request.GET.view == None %}
+            {% if request.GET.view == 'committees' or request.GET.view == None %}
 
                 <h3>
                     <i class='fa fa-fw fa-group'></i>
                     Committees
                 </h3>
+
+                <p>Committees to which {{person.name}} belongs</p><br />
 
                 <div class="table-responsive">
                     <table class='table table-responsive'>
@@ -142,6 +131,7 @@
                             <tr>
                                 <th>Member of</th>
                                 <th>Position</th>
+                                <th>Committee actions</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -151,11 +141,28 @@
                                         <a href="{% url 'lametro:committee' membership.organization.slug %}">{{membership.organization}}</a>
                                     </td>
                                     <td>{{membership.role}}</td>
+                                    <td>
+                                        <a href="/search/?q=&selected_facets=sponsorships_exact:{{membership.organization.name}}">View board reports &raquo;</a>
+                                    </td>
                                 </tr>
                             {% endfor %}
                         </tbody>
                     </table>
                 </div>
+
+            {% elif request.GET.view == 'board-reports' %}
+                <h3>
+                    <i class='fa fa-fw fa-files-o'></i>
+                    Board Reports
+                </h3>
+
+                <p>Board reports acted upon most recently by committees to which {{person.name}} belongs</p><br />
+
+                {% for legislation in sponsored_legislation %}
+
+                    {% include "partials/legislation_item.html" %}
+
+                {% endfor %}
 
             {% endif %}
 

--- a/lametro/templates/lametro/person.html
+++ b/lametro/templates/lametro/person.html
@@ -98,33 +98,67 @@
                 <p>{{ member_bio | safe }}</p><br />
             {% endif %}
 
+            <ul class="nav nav-pills">
+                <li role="presentation" {% if request.GET.view == 'committees'  or request.GET.view == None %}class='active' {% endif %}>    <a href="/person/{{person.slug}}/?view=committees">
+                        <span class="small-pill">
+                            <i class='fa fa-fw fa-group'></i>
+                            Committees
+                        </span>
+                    </a>
+                </li>
+                <li role="presentation" {% if request.GET.view == 'bills' %}class='active' {% endif %}>
+                    <a href="/person/{{person.slug}}/?view=bills">
+                        <span class="small-pill">
+                            <i class='fa fa-fw fa-files-o'></i>
+                            Board Reports
+                        </span>
+                    </a>
+                </li>
+            </ul>
 
-            {% if memberships_list %}
-            <h3>
-                <i class='fa fa-fw fa-group'></i> Committees
-            </h3>
+            {% if request.GET.view == 'bills' %}
+                <h3>
+                    <i class='fa fa-fw fa-files-o'></i>
+                    Board Reports
+                </h3>
+                <p>Board reports considered by committees of which {{person.name}} is a member</p><br/>
 
-            <div class="table-responsive">
-                <table class='table table-responsive'>
-                    <thead>
-                        <tr>
-                            <th>Member of</th>
-                            <th>Position</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for membership in memberships_list %}
+                {% for legislation in sponsored_legislation %}
+
+                    {% include "partials/legislation_item.html" %}
+
+                {% endfor %}
+
+            {% elif request.GET.view == 'committees' or request.GET.view == None %}
+
+                <h3>
+                    <i class='fa fa-fw fa-group'></i>
+                    Committees
+                </h3>
+
+                <div class="table-responsive">
+                    <table class='table table-responsive'>
+                        <thead>
                             <tr>
-                                <td>
-                                    <a href="{% url 'lametro:committee' membership.organization.slug %}">{{membership.organization}}</a>
-                                </td>
-                                <td>{{membership.role}}</td>
+                                <th>Member of</th>
+                                <th>Position</th>
                             </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
+                        </thead>
+                        <tbody>
+                            {% for membership in memberships_list %}
+                                <tr>
+                                    <td>
+                                        <a href="{% url 'lametro:committee' membership.organization.slug %}">{{membership.organization}}</a>
+                                    </td>
+                                    <td>{{membership.role}}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+
             {% endif %}
+
         </div>
     </div>
     {% endif %}

--- a/lametro/templates/partials/search_result.html
+++ b/lametro/templates/partials/search_result.html
@@ -4,10 +4,7 @@
 
 <p>
     <a class="small" href="{% url 'lametro:bill_detail' r.object.slug %}">
-        {{ r.object.identifier}}
-        {% if r.sort_name %}
-            - {{r.sort_name|upper}}
-        {% endif %}
+        {{ r.object.friendly_name }}
     </a>
     {% if r.object.inferred_status %}{{ r.object.inferred_status | inferred_status_label | safe }}{% endif %}
 </p>


### PR DESCRIPTION
## Overview

This PR:

- Adds board reports back to the person page, replacing sponsorship language with "acted upon by committees to which X belongs", handles #559 
- Revises `LAMetroBill.friendly_name` to be consistent with search results, handles #568

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

![Screen Shot 2020-10-09 at 4 24 22 PM](https://user-images.githubusercontent.com/12176173/95632952-51bc0180-0a4c-11eb-9118-c8c2659091f3.png)
![Screen Shot 2020-10-09 at 4 24 36 PM](https://user-images.githubusercontent.com/12176173/95632956-54b6f200-0a4c-11eb-90d2-da7259f8f647.png)


## Testing Instructions

 * On the staging site (https://lametro-upgrade.datamade.us), navigate to the board members page, then click on a board member to view their detail page. 
* Confirm the board member detail page defaults to showing committees. Select a committee in the table, making note of its name. Click `View actions`, then click a search result and confirm that the board report detail page shows an action by the committee you selected.
* Navigate back to the board member detail page, and click `Board reports`. Confirm that the page reloads and shows five board reports. Click on one and confirm that it has an action by a committee to which the board member belongs.
* Read over the new text and confirm it makes sense.
