### PR TITLE
Include appearing on agenda in board report history, update columns, sort scheduled first

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -212,15 +212,10 @@ class LAMetroBill(Bill, SourcesMixin):
 
             data.append(event_dict)
 
-        scheduled_first = []
-        for d in data:
-            if d['description'] == 'SCHEDULED':
-                scheduled_first.append(d)
-        for d in data:
-            if d['description'] != 'SCHEDULED':
-                scheduled_first.append(d)
-
-        sorted_data = sorted(scheduled_first, key=lambda x: x['date'])
+        sorted_data = sorted(data, key=lambda x: (x['date'], x['description'].upper() if x['description'] == 'SCHEDULED' else x['description'].lower()))
+        
+        import pdb
+        pdb.set_trace()
 
         return sorted_data
 

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -212,7 +212,8 @@ class LAMetroBill(Bill, SourcesMixin):
 
             data.append(event_dict)
 
-        sorted_data = sorted(data, key=lambda x: (x['date'], x['description'].upper() if x['description'] == 'SCHEDULED' else x['description'].lower()))
+        sorted_data = sorted(data, key=lambda x:(x['date'],\
+            x['description'].upper() if x['description'] == 'SCHEDULED' else x['description'].lower()))
         
         import pdb
         pdb.set_trace()

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -213,6 +213,7 @@ class LAMetroBill(Bill, SourcesMixin):
             data.append(event_dict)
 
         # Sort actions by date, and list SCHEDULED actions before other actions on that date
+        # SCHEDULED descriptions are kept uppercase to use ascii-betical sorting
         sorted_data = sorted(data, key=lambda x:(x['date'],\
             x['description'].upper() if x['description'] == 'SCHEDULED' else x['description'].lower()))
 

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -212,11 +212,9 @@ class LAMetroBill(Bill, SourcesMixin):
 
             data.append(event_dict)
 
+        # Sort actions by date, and list SCHEDULED actions before other actions on that date
         sorted_data = sorted(data, key=lambda x:(x['date'],\
             x['description'].upper() if x['description'] == 'SCHEDULED' else x['description'].lower()))
-        
-        import pdb
-        pdb.set_trace()
 
         return sorted_data
 

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -205,14 +205,22 @@ class LAMetroBill(Bill, SourcesMixin):
             org = event.participants.first()
             event_dict = {
                 'date': event.start_time.date(),
-                'description': "SCHEDULED",
+                'description': 'SCHEDULED',
                 'event': event,
                 'organization': org
             }
 
             data.append(event_dict)
 
-        sorted_data = sorted(data, key=lambda x: x['date'])
+        scheduled_first = []
+        for d in data:
+            if d['description'] == 'SCHEDULED':
+                scheduled_first.append(d)
+        for d in data:
+            if d['description'] != 'SCHEDULED':
+                scheduled_first.append(d)
+
+        sorted_data = sorted(scheduled_first, key=lambda x: x['date'])
 
         return sorted_data
 

--- a/lametro/templates/lametro/legislation.html
+++ b/lametro/templates/lametro/legislation.html
@@ -93,24 +93,24 @@
                             <tr>
                                 <th>Date</th>
                                 <th>Action</th>
-                                <th>Committee</th>
+                                <th>Meeting</th>
                             </tr>
                         </thead>
                         <tbody>
                             {% for action in actions %}
                                 <tr>
                                     <td class='nowrap text-muted small'>
-                                        <span datetime='{{action.date_dt | format_date_sort }}'>{{action.date_dt|date:'n/d/y'}}</span>
+                                        <span datetime='{{action.date}}'>{{action.date|date:'n/d/y'}}</span>
                                     </td>
                                     <td class="small">
-                                        <span class='text-{{action.label}}'>{{action.description | remove_action_subj}}</span>
-                                        {% if action.related_organization %}
-                                            to
-                                            {{action.related_organization.link_html|safe}}
+                                        <span class='text-default'>{{action.description}}</span>
+                                    </td>
+                                    <td class="small">
+                                        {% if action.event.status == 'cancelled' %}<strike>{% endif %}
+                                        {{ action.event.link_html|safe }}
+                                        {% if action.event.status == 'cancelled' %}</strike>
+                                            <small>&nbsp;<span class="label label-stale">{{ action.event.status }}</span></small>
                                         {% endif %}
-                                    </td>
-                                    <td class="small">
-                                        {{action.organization.link_html|safe}}
                                     </td>
                                 </tr>
                             {% endfor %}

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -221,7 +221,6 @@ def all_have_extra(entities, extra):
     '''
     return all(e.extras.get(extra, None) for e in entities)
 
-
 @register.filter
 def get_list(querydict, key):
     return querydict.getlist(key)

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -83,11 +83,11 @@ class LABillDetail(BillDetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['actions'] = self.get_object().actions.all().order_by('-order')
-        context['attachments'] = self.get_object().attachments.all().order_by(Lower('note'))
+        bill = self.get_object()
 
-        item = context['legislation']
-        actions = self.get_object().actions.all()
+        context['attachments'] = bill.attachments.all().order_by(Lower('note'))
+
+        actions = bill.actions.all()
         organization_lst = [action.organization for action in actions]
         context['sponsorships'] = set(organization_lst)
 
@@ -98,6 +98,8 @@ class LABillDetail(BillDetailView):
             .order_by('-latest_date')
 
         context['related_bills'] = related_bills
+
+        context['actions'] = bill.actions_and_agendas
 
         return context
 


### PR DESCRIPTION
## Overview
This PR
* Adds an actions_and_agendas property to the LAMetroBill model that includes information about events and agendas, their times, descriptions, and related organizations
* Updates the legislation.html template (for the LAMetroBill model) with the data from this property

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

* Navigate to a piece of legislation
* Hard refresh the page
* Confirm link goes to appropriate event agenda
* Confirm event status is correct
* Repeat with a few different pages

Handles #348 
