### PR TITLE
Boost search results with identifier/s matching query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ debug.log
 /configs/settings_deployment.staging.py
 
 *.csv
+.gnupg/

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -617,7 +617,7 @@ class IdentifierBoostSearchQuery(SolrSearchQuery):
         if identifiers:
             kwargs.update({
                 'defType': 'edismax',
-                'bq': '+'.join('identifier:{}^2.0'.format(i) for i in identifiers),
+                'bq': '+'.join('identifier:"{}"^2.0'.format(i) for i in identifiers),
             })
 
         return super().run(spelling_query, **kwargs)


### PR DESCRIPTION
## Overview

This PR subclasses `SolrSearchQuery` and extends the `run()` method to add additional search kwargs if the query contains an identifier. The effect of these extra kwargs doubles the score of results with an identifier matching the query, hopefully ensuring that they are returned first. 

N.b., Haystack `SearchQueryset` objects contain methods to boost terms in general, but I wanted a more targeted matching strategy (boost results where the `identifier` field, specifically, matches the query) because full text can contain several identifiers, e.g., agendas, which could yield unexpected results.

#### Further reading

- `SearchQuery` API: https://django-haystack.readthedocs.io/en/master/searchquery_api.html
- Blog on how to order matching results first: https://medium.com/@pablocastelnovo/if-they-match-i-want-them-to-be-always-first-boosting-documents-in-apache-solr-with-the-boost-362abd36476c

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

To be done on the staging site:

 * Search `2018-0101` and confirm that the corresponding board report appears first in the results.

Handles #487 
