### PR TITLE
Strike out cancelled meetings on committee detail page

### DIFF
--- a/lametro/templates/lametro/committee.html
+++ b/lametro/templates/lametro/committee.html
@@ -31,8 +31,15 @@
                 </h4>
                 <br>
                 {% for event in committee.recent_events %}
-                    <p class='event-listing'>
-                        {{event.start_time | date:'n/d/Y' }} - {{event.link_html | safe}}
+                    <p class="event-listing">
+                    {% if event.status == 'cancelled' %}
+                        <strike>
+                            {{ event.start_time | date:'n/d/Y' }} - {{ event.link_html | safe }}
+                        </strike>
+                        <span class="label label-stale">Cancelled</span>
+                    {% else %}
+                        {{ event.start_time | date:'n/d/Y' }} - {{ event.link_html | safe}}
+                    {% endif %}
                     </p>
                 {% endfor %}
                 <a href="" id="more-events"><i class="fa fa-fw fa-chevron-down"></i>Show more</a>


### PR DESCRIPTION
## Overview

See title.

## Demo

![Screen Shot 2020-12-04 at 3 28 58 PM](https://user-images.githubusercontent.com/12176173/101216623-734cfa00-3645-11eb-9060-7a66f29f385b.png)

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

I deployed this to the staging site, so you can do testing there!

 * View [the Finance, Budget, and Audit Committee page](https://lametro-upgrade.datamade.us/committee/finance-budget-and-audit-committee-d2000bac9379/) and confirm the 5/20 meeting is displayed as cancelled.

Handles #613
