### PR TITLE
Try referencing CodeDeploy action by commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,6 @@ jobs:
           aws-region: us-east-1
       - uses: actions/checkout@v2
       - id: deploy
-        uses: webfactory/create-aws-codedeploy-deployment@v0.2.1
+        uses: webfactory/create-aws-codedeploy-deployment@0d7a684950dae16883a140dd950257958730e0b5
         with:
           application: la-metro-councilmatic


### PR DESCRIPTION
## Overview

There's a fix for a bug we've been seeing with deployments that isn't in the latest release. This PR references the action by commit hash to capture that fix. (Not sure if this works, but we'll see!)

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

We should update this to point to a release when one becomes available.

## Testing Instructions

 * Confirm that a build is created (i.e., the GitHub Actions syntax is correct) and that the CodeDeploy action runs, logging a message that the branch does not match a deployment config.
 * On merge, confirm a staging deployment is created.
