### PR TITLE
re-add meetings facet

### DIFF
--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -29,7 +29,7 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         return None
 
     def prepare_sponsorships(self, obj):
-        return [action.organization for action in obj.actions.all()]
+        return [action.organization for action in obj.actions_and_agendas.all()]
 
     def prepare_sort_name(self, obj):
         full_text = obj.extras.get('plain_text')

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -29,7 +29,8 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         return None
 
     def prepare_sponsorships(self, obj):
-        return [action.organization for action in obj.actions_and_agendas.all()]
+        orgs_list = [action.organization for action in obj.actions_and_agendas.all()]
+        return set(orgs_list)
 
     def prepare_sort_name(self, obj):
         full_text = obj.extras.get('plain_text')

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -29,7 +29,7 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         return None
 
     def prepare_sponsorships(self, obj):
-        orgs_list = [action.organization for action in obj.actions_and_agendas]
+        orgs_list = [action['organization'].name for action in obj.actions_and_agendas]
         return set(orgs_list)
 
     def prepare_sort_name(self, obj):

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -29,7 +29,7 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         return None
 
     def prepare_sponsorships(self, obj):
-        orgs_list = [action.organization for action in obj.actions_and_agendas.all()]
+        orgs_list = [action.organization for action in obj.actions_and_agendas]
         return set(orgs_list)
 
     def prepare_sort_name(self, obj):

--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -127,7 +127,7 @@
 
             <!-- Meetings -->
             {% if facets.fields.sponsorships %}
-                {% with facet_name='sponsorships' facet_label='Meetings' item_list=facets.fields.sponsorships selected_list=selected_facets.sponsorships %}
+                {% with facet_name='sponsorships' facet_label='Meeting' item_list=facets.fields.sponsorships selected_list=selected_facets.sponsorships %}
                     {% include 'partials/search_filter.html' %}
                 {% endwith %}
             {% endif %}

--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -125,6 +125,13 @@
                 {% endwith %}
             {% endif %}
 
+            <!-- Meetings -->
+            {% if facets.fields.sponsorships %}
+                {% with facet_name='sponsorships' facet_label='Meetings' item_list=facets.fields.sponsorships selected_list=selected_facets.sponsorships %}
+                    {% include 'partials/search_filter.html' %}
+                {% endwith %}
+            {% endif %}
+
             <div class="divider"></div>
 
             <div id="related-terms" class="hidden">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -226,7 +226,7 @@ def metro_organization(db):
 
             organization_info = {
                 'id': 'ocd-organization/' + uid,
-                'name': 'Planning and Programming Committee',
+                'name': 'Planning and Programming Committee ' + uid,
                 'slug': 'planning-and-programming-committee-' + get_uid_chunk(uid),
             }
 

--- a/tests/test_solr_prep.py
+++ b/tests/test_solr_prep.py
@@ -31,37 +31,16 @@ def test_legislative_session(bill,
 
     assert indexed_data['legislative_session'] == prepared_session
 
-@pytest.mark.parametrize('session_identifier,prepared_session', [
-    ('2014', '7/1/2014 to 6/30/2015'),
-    ('2015', '7/1/2015 to 6/30/2016'),
-    ('2016', '7/1/2016 to 6/30/2017'),
-    ('2017', '7/1/2017 to 6/30/2018'),
-    ('2018', '7/1/2018 to 6/30/2019'),
-])
 def test_sponsorships(bill, 
                       legislative_session,
-                      session_identifier,
-                      prepared_session,
                       metro_organization,
                       event,
                       mocker):
-    '''
-    This test instantiates LAMetroBillIndex – a subclass of SearchIndex from
-    Haystack, used for building the Solr index.
-
-    The test, then, calls the SearchIndex `prepare` function, 
-    which returns a dict of prepped data.
-    https://github.com/django-haystack/django-haystack/blob/4910ccb01c31d12bf22dcb000894eece6c26f74b/haystack/indexes.py#L198
-    '''
-    legislative_session.identifier = session_identifier
-    legislative_session.save()
-    bill = bill.build(legislative_session=legislative_session)
+    bill = bill.build()
 
     org1 = metro_organization.build()
     org2 = metro_organization.build()
     event1 = event.build()
-    # event2 = event.build()
-    # event3 = event.build()
     actions_and_agendas = [
         {
             'date': datetime.now(),

--- a/tests/test_solr_prep.py
+++ b/tests/test_solr_prep.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime
 
 from lametro.search_indexes import LAMetroBillIndex
 
@@ -29,3 +30,65 @@ def test_legislative_session(bill,
     indexed_data = index.prepare(bill)
 
     assert indexed_data['legislative_session'] == prepared_session
+
+@pytest.mark.parametrize('session_identifier,prepared_session', [
+    ('2014', '7/1/2014 to 6/30/2015'),
+    ('2015', '7/1/2015 to 6/30/2016'),
+    ('2016', '7/1/2016 to 6/30/2017'),
+    ('2017', '7/1/2017 to 6/30/2018'),
+    ('2018', '7/1/2018 to 6/30/2019'),
+])
+def test_sponsorships(bill, 
+                      legislative_session,
+                      session_identifier,
+                      prepared_session,
+                      metro_organization,
+                      event,
+                      mocker):
+    '''
+    This test instantiates LAMetroBillIndex – a subclass of SearchIndex from
+    Haystack, used for building the Solr index.
+
+    The test, then, calls the SearchIndex `prepare` function, 
+    which returns a dict of prepped data.
+    https://github.com/django-haystack/django-haystack/blob/4910ccb01c31d12bf22dcb000894eece6c26f74b/haystack/indexes.py#L198
+    '''
+    legislative_session.identifier = session_identifier
+    legislative_session.save()
+    bill = bill.build(legislative_session=legislative_session)
+
+    org1 = metro_organization.build()
+    org2 = metro_organization.build()
+    event1 = event.build()
+    # event2 = event.build()
+    # event3 = event.build()
+    actions_and_agendas = [
+        {
+            'date': datetime.now(),
+            'description': 'org1 description',
+            'event': event1,
+            'organization': org1
+        },
+        {
+            'date': datetime.now(),
+            'description': 'org2 descripton',
+            'event': event1,
+            'organization': org2
+        },
+        {
+            'date': datetime.now(),
+            'description': 'org2 descripton',
+            'event': event1,
+            'organization': org2
+        }
+    ]
+    import pdb
+    pdb.set_trace()
+    mock_actions_and_agendas = mocker.patch('lametro.models.LAMetroBill.actions_and_agendas',\
+                                            new_callable=mocker.PropertyMock,\
+                                            return_value=actions_and_agendas)
+
+    index = LAMetroBillIndex()
+    indexed_data = index.prepare(bill)
+
+    assert indexed_data['sponsorships'] == {org1.name, org2.name}

--- a/tests/test_solr_prep.py
+++ b/tests/test_solr_prep.py
@@ -32,7 +32,6 @@ def test_legislative_session(bill,
     assert indexed_data['legislative_session'] == prepared_session
 
 def test_sponsorships(bill, 
-                      legislative_session,
                       metro_organization,
                       event,
                       mocker):

--- a/tests/test_solr_prep.py
+++ b/tests/test_solr_prep.py
@@ -82,8 +82,6 @@ def test_sponsorships(bill,
             'organization': org2
         }
     ]
-    import pdb
-    pdb.set_trace()
     mock_actions_and_agendas = mocker.patch('lametro.models.LAMetroBill.actions_and_agendas',\
                                             new_callable=mocker.PropertyMock,\
                                             return_value=actions_and_agendas)


### PR DESCRIPTION
## Overview

This PR adds back the `Meetings` facet that got lost. 

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

Based on the searches I tried, I didn't ever see any duplicate organizations, but I still went ahead and added logic to prevent duplication.

## Testing Instructions

 * Update haystack index using `docker-compose run --rm app python manage.py update_index`
 * Search something, like `red line`, and verify that the `Meetings` facet appears on the left side of the page with the other filters.
 * Expand the `Meetings` filter and make sure there are no duplicate organizations.
 * run tests using `docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app` to check new test, `test_sponsorships`, and to make sure change to organization factory in test fixtures doesn't break other tests

Handles #537 
