### PR TITLE
Add help text for viewing embedded hyperlinks

### DIFF
--- a/lametro/templates/lametro/legislation.html
+++ b/lametro/templates/lametro/legislation.html
@@ -45,6 +45,11 @@
                 </h3>
 
                 <p>
+                    To access embedded hyperlinks, please download the report PDF by clicking "Download Board Report".
+                </p>
+
+
+                <p>
                     <a id="pdf-download-link" target='_blank' href='{{board_report.url}}'><i class="fa fa-file-text-o" aria-hidden="true"></i> Download Board Report</a>
                 </p>
 


### PR DESCRIPTION
## Overview

See title.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

![Screen Shot 2021-01-19 at 1 37 08 PM](https://user-images.githubusercontent.com/12176173/105084193-a0b9ff80-5a5b-11eb-9606-44901097b57a.png)

## Testing Instructions

 * View a board report and confirm that you see the next help text below the `Report text` heading, before the PDF.

Handles #294
