### PR TITLE
Event delete button for duplicated events not in Legistar

### DIFF
--- a/councilmatic/urls.py
+++ b/councilmatic/urls.py
@@ -15,7 +15,7 @@ from lametro.api import SmartLogicAPI, PublicComment, refresh_guid_trigger, \
 from lametro.views import LAMetroIndexView, LAMetroEventDetail, LABillDetail, LABoardMembersView, \
     LAMetroAboutView, LACommitteeDetailView, LACommitteesView, LAPersonDetailView, \
     LAMetroEventsView, LAMetroCouncilmaticFacetedSearchView, GoogleView, \
-    metro_login, metro_logout, delete_submission, LAMetroArchiveSearch
+    metro_login, metro_logout, delete_submission, delete_event, LAMetroArchiveSearch
 from lametro.feeds import *
 
 patterns = ([
@@ -49,6 +49,7 @@ urlpatterns = [
     url(r'^subjects/$', fetch_subjects, name='subjects'),
     url(r'^object-counts/(.*)$', fetch_object_counts, name='object_counts'),
     url(r'^delete-submission/(?P<event_slug>[^/]+)/$', delete_submission, name='delete_submission'),
+    url(r'^delete-event/(?P<event_slug>[^/]+)/$', delete_event, name='delete_event'),
     url(r'', include('councilmatic_core.urls')),
 ]
 

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -41,6 +41,14 @@
                         <a class="btn btn-salmon" href="{{ media.links.all.0.url }}" target="_blank"><i class= "fa fa-headphones" aria-hidden="true"></i> {% if media.note == 'Audio (SAP)' %}Ver en Español{% else %}Watch in English{% endif %}</a>
                     {% endfor %}
                 {% endif %}
+                {% if user.is_authenticated %}
+                    {% if event_ok %}
+                        <h1>Event's ok!</h1>
+                    {% else %}
+                        <h1>Event's not ok</h1>
+                    {% endif %}
+                {% endif %}
+
             </h1>
 
             <div class="row">

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -45,7 +45,7 @@
                     {% if not event_ok %}
                     <div class="well">
                         <p>This event does not exist in Legistar. It may have been deleted from Legistar due to being a duplicate. To delete this event, click the button below.</p>
-                        <a href="{% url 'delete_event' event.slug %}" class='btn btn-teal'><i class="fa fa-times" aria-hidden="true"></i> Delete Event</a>
+                        <a href="{% url 'delete_event' event.slug %}" class='btn btn-teal'><i class="fa fa-times" aria-hidden="true"></i>Delete Event</a>
                     </div>
                     {% endif %}
                 {% endif %}

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -42,10 +42,11 @@
                     {% endfor %}
                 {% endif %}
                 {% if user.is_authenticated %}
-                    {% if event_ok %}
-                        <h1>Event's ok!</h1>
-                    {% else %}
-                        <h1>Event's not ok</h1>
+                    {% if not event_ok %}
+                    <div class="well">
+                        <p>This event does not exist in Legistar. It may have been deleted from Legistar due to being a duplicate. To delete this event, click the button below.</p>
+                        <a href="{% url 'delete_event' event.slug %}" class='btn btn-teal'><i class="fa fa-times" aria-hidden="true"></i> Delete Event</a>
+                    </div>
                     {% endif %}
                 {% endif %}
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -23,6 +23,7 @@ from django.db import transaction, connection, connections
 from django.conf import settings
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.auth.decorators import login_required
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.shortcuts import render
 from django.db.models.functions import Lower, Now, Cast
@@ -238,6 +239,7 @@ def handle_uploaded_agenda(agenda, event):
     management.call_command('collectstatic', '--noinput')
 
 
+@login_required
 def delete_submission(request, event_slug):
     event = LAMetroEvent.objects.get(slug=event_slug)
     event_doc = EventDocument.objects.filter(event_id=event.id, note__icontains='Manual upload')
@@ -254,6 +256,7 @@ def delete_submission(request, event_slug):
     return HttpResponseRedirect('/event/%s' % event_slug)
 
 
+@login_required
 def delete_event(request, event_slug):
     event = LAMetroEvent.objects.get(slug=event_slug)
     event.delete()

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -255,18 +255,8 @@ def delete_submission(request, event_slug):
 
 
 def delete_event(request, event_slug):
-    # event = LAMetroEvent.objects.get(slug=event_slug)
-    # event_doc = EventDocument.objects.filter(event_id=event.id, note__icontains='Manual upload')
-
-    # for e in event_doc:
-    #     # Remove stored PDF from Metro app.
-    #     if 'Manual upload PDF' in e.note:
-    #         try:
-    #             os.remove('lametro/static/%s' % e.links.get().url )
-    #         except OSError:
-    #             pass
-    #     e.delete()
-
+    event = LAMetroEvent.objects.get(slug=event_slug)
+    event.delete()
     return HttpResponseRedirect('/events/')
 
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -160,6 +160,12 @@ class LAMetroEventDetail(EventDetailView):
             r = requests.get('https://metro.legistar.com/calendar.aspx')
             context['legistar_ok'] = r.ok
 
+        event_gid = event.api_source.url.split('/')[-1]
+        response = requests.get('https://metro.legistar.com/MeetingDetail.aspx?LEGID={}&GID=557&G=A5FAA737-A54D-4A6C-B1E8-FF70F765FA94'.format(event_gid))
+        # response = requests.get('https://metro.legistar.com/MeetingDetail.aspx?LEGID=3&GID=557&G=A5FAA737-A54D-4A6C-B1E8-FF70F765FA94')
+        string_in_content = response.content.find(b'This record no longer exists. It might have been deleted.')
+        context['event_in_legistar'] = not bool(string_in_content)
+
         try:
             context['minutes'] = event.documents.get(note__icontains='minutes')
         except EventDocument.DoesNotExist:
@@ -214,6 +220,9 @@ class LAMetroEventDetail(EventDetailView):
 
         context['USING_ECOMMENT'] = settings.USING_ECOMMENT
 
+        import pdb
+        pdb.set_trace()
+
         return context
 
 
@@ -249,6 +258,22 @@ def delete_submission(request, event_slug):
         e.delete()
 
     return HttpResponseRedirect('/event/%s' % event_slug)
+
+
+def delete_event(request, event_slug):
+    # event = LAMetroEvent.objects.get(slug=event_slug)
+    # event_doc = EventDocument.objects.filter(event_id=event.id, note__icontains='Manual upload')
+
+    # for e in event_doc:
+    #     # Remove stored PDF from Metro app.
+    #     if 'Manual upload PDF' in e.note:
+    #         try:
+    #             os.remove('lametro/static/%s' % e.links.get().url )
+    #         except OSError:
+    #             pass
+    #     e.delete()
+
+    return HttpResponseRedirect('/events/')
 
 
 class LAMetroEventsView(EventsView):

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -162,7 +162,7 @@ class LAMetroEventDetail(EventDetailView):
             context['legistar_ok'] = r.ok
             # GET the event URL; allow admin to delete event if 404
             response = requests.get(event.api_source.url)
-            context['event_ok'] = True if response.status_code == 200 else False
+            context['event_ok'] = response.ok
 
         try:
             context['minutes'] = event.documents.get(note__icontains='minutes')

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -159,12 +159,9 @@ class LAMetroEventDetail(EventDetailView):
         if self.request.user.is_authenticated:
             r = requests.get('https://metro.legistar.com/calendar.aspx')
             context['legistar_ok'] = r.ok
-
-        event_gid = event.api_source.url.split('/')[-1]
-        response = requests.get('https://metro.legistar.com/MeetingDetail.aspx?LEGID={}&GID=557&G=A5FAA737-A54D-4A6C-B1E8-FF70F765FA94'.format(event_gid))
-        # response = requests.get('https://metro.legistar.com/MeetingDetail.aspx?LEGID=3&GID=557&G=A5FAA737-A54D-4A6C-B1E8-FF70F765FA94')
-        string_in_content = response.content.find(b'This record no longer exists. It might have been deleted.')
-        context['event_in_legistar'] = not bool(string_in_content)
+            # GET the event URL; allow admin to delete event if 404
+            response = requests.get(event.api_source.url)
+            context['event_ok'] = True if response.status_code == 200 else False
 
         try:
             context['minutes'] = event.documents.get(note__icontains='minutes')
@@ -219,9 +216,6 @@ class LAMetroEventDetail(EventDetailView):
 
 
         context['USING_ECOMMENT'] = settings.USING_ECOMMENT
-
-        import pdb
-        pdb.set_trace()
 
         return context
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ gunicorn==19.6.0
 pytest
 pytest-django
 pytest-mock==1.6.3
+requests-mock==1.8.0
 freezegun==1.0.0
 lxml==4.1.1
 dj_database_url

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -372,6 +372,7 @@ def test_delete_event(event, client, admin_client):
 
     user_response = client.get(delete_event)
     assert user_response.url != admin_redirect_url
+    assert event_in_db.exists()
 
     admin_response = admin_client.get(delete_event)
     assert admin_response.url == admin_redirect_url

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -360,11 +360,18 @@ def test_delete_button_shows(event, client, django_user_model, mocker):
         failure = m.get(source_matcher, status_code=404)
         failure_response = client.get(event_template)
 
-
         assert 'This event does not exist in Legistar. It may have been deleted from Legistar due to being a duplicate. To delete this event, click the button below.' not in success_response.content.decode('utf-8')
         assert 'This event does not exist in Legistar. It may have been deleted from Legistar due to being a duplicate. To delete this event, click the button below.' in failure_response.content.decode('utf-8')
 
-    # ping the url attached to the button and then…
-    # assertion: event no longer exists
 
-# def test_delete_duplicate_events():
+@pytest.mark.django_db
+def test_delete_event(event, client):
+    e = event.build()
+    e.save()
+    event_in_db = LAMetroEvent.objects.filter(id=e.id)
+    assert event_in_db.exists()
+
+    delete_event = reverse('delete_event', args=[e.slug])
+    response = client.get(delete_event)
+    event_in_db = LAMetroEvent.objects.filter(id=e.id)
+    assert not event_in_db.exists()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -369,8 +369,6 @@ def test_delete_event(event, client, admin_client):
 
     delete_event = reverse('delete_event', args=[e.slug])
     admin_redirect_url = reverse('lametro:event')
-    import pdb
-    pdb.set_trace()
 
     user_response = client.get(delete_event)
     assert user_response.url != admin_redirect_url

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.utils import timezone
 from freezegun import freeze_time
 import requests
+import requests_mock
 
 from opencivicdata.legislative.models import EventDocument
 from councilmatic_core.models import Bill
@@ -327,3 +328,19 @@ def test_event_is_upcoming(event, mocker):
 
     with freeze_time(tomorrow_morning):
         assert not test_event.is_upcoming
+
+
+def test_delete_duplicate_event(event, requests_mock):
+    # create 1 event with a fake api_source and use requests_mock to come up with 2 different responses (an ok and a 404)
+    e = event.build()
+    event_url = 'http://webapi.legistar.com/v1/metro/events/0000'
+    with requests_mock.Mocker() as m:
+        success = m.get(event_url, status_code=200)
+        failure = m.get(event_url, status_code=404)
+
+        import pdb
+        pdb.set_trace()
+        assert True
+    # assertion: template generated with 404 response has the delete event button
+    # ping the url attached to the button and then…
+    # assertion: event no longer exists

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -330,16 +330,14 @@ def test_event_is_upcoming(event, mocker):
         assert not test_event.is_upcoming
 
 
-def test_delete_duplicate_event(event, requests_mock):
+def test_delete_duplicate_event(event):
     # create 1 event with a fake api_source and use requests_mock to come up with 2 different responses (an ok and a 404)
     e = event.build()
     event_url = 'http://webapi.legistar.com/v1/metro/events/0000'
     with requests_mock.Mocker() as m:
         success = m.get(event_url, status_code=200)
         failure = m.get(event_url, status_code=404)
-
-        import pdb
-        pdb.set_trace()
+        
         assert True
     # assertion: template generated with 404 response has the delete event button
     # ping the url attached to the button and then…

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -368,12 +368,15 @@ def test_delete_event(event, client, admin_client):
     assert event_in_db.exists()
 
     delete_event = reverse('delete_event', args=[e.slug])
+    admin_redirect_url = reverse('lametro:event')
+    import pdb
+    pdb.set_trace()
 
     user_response = client.get(delete_event)
-    assert user_response.url != '/events/'
+    assert user_response.url != admin_redirect_url
 
     admin_response = admin_client.get(delete_event)
-    assert admin_response.url == '/events/'
+    assert admin_response.url == admin_redirect_url
 
     event_in_db = LAMetroEvent.objects.filter(id=e.id)
     assert not event_in_db.exists()


### PR DESCRIPTION
## Overview

This PR adds a button to an event page's header to delete the event from the database if it does not exist in Legistar. This happens when a duplicated version of an event has been deleted from Legistar but the object still exists in the database.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * run `docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app` and make sure all tests pass

Handles #692 
