### PR TITLE
Override haystack.utils.default_get_identifier

### DIFF
--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -118,5 +118,6 @@ PIC_BASE_URL = 'https://pic.datamade.us/lametro/document/'
 # PIC_BASE_URL = 'http://127.0.0.1:5000/lametro/document/'
 
 HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
+HAYSTACK_IDENTIFIER_METHOD = 'lametro.utils.get_identifier'
 
 ADV_CACHE_INCLUDE_PK = True

--- a/lametro/utils.py
+++ b/lametro/utils.py
@@ -39,3 +39,13 @@ def format_full_text(full_text):
 def parse_subject(text):
     if ('[PROJECT OR SERVICE NAME]' not in text) and ('[DESCRIPTION]' not in text) and ('[CONTRACT NUMBER]' not in text):
         return text.strip()
+
+def get_identifier(obj_or_string):
+    # obj_or_string is the ocd-bill string or an instance of a bill
+    # return id always
+    # id == ocd-bill string
+
+    # to test:
+    # run update_index locally
+    # delete a bill in a django shell
+    # run update_index --remove locally so that this method runs

--- a/lametro/utils.py
+++ b/lametro/utils.py
@@ -8,8 +8,6 @@ from lxml.etree import tostring
 from django.conf import settings
 from django.utils import timezone
 
-from councilmatic_core.models import Organization, Event
-
 app_timezone = pytz.timezone(settings.TIME_ZONE)
 
 def format_full_text(full_text):
@@ -41,11 +39,6 @@ def parse_subject(text):
         return text.strip()
 
 def get_identifier(obj_or_string):
-    if isinstance(obj_or_string, string):
+    if isinstance(obj_or_string, str):
         return obj_or_string
-    return bill.id
-
-    # to test:
-    # run update_index locally
-    # delete a bill in a django shell
-    # run update_index --remove locally so that this method runs
+    return obj_or_string.id

--- a/lametro/utils.py
+++ b/lametro/utils.py
@@ -41,9 +41,9 @@ def parse_subject(text):
         return text.strip()
 
 def get_identifier(obj_or_string):
-    # obj_or_string is the ocd-bill string or an instance of a bill
-    # return id always
-    # id == ocd-bill string
+    if isinstance(obj_or_string, string):
+        return obj_or_string
+    return bill.id
 
     # to test:
     # run update_index locally


### PR DESCRIPTION
## Overview

This PR compliments [la-metro-dashboard/pull/72](https://github.com/datamade/la-metro-dashboard/pull/72), which adds the `--remove` option to the `update_index` command.

This PR overrides haystack's `default_get_identifier` method, which provides the first step in deleting records from the haystack index. We override haystack's `id` property, so this code returns the identifier formats we use rather than the default haystack format.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes
The `update_index` command cleared the index out before recreating it when I ran it locally. I spent a few minutes trying to see if I could find this management command, but I couldn't find it in `la-metro-councilmatic` or `django-councilmatic`. I was hoping to identify where this command lives to double-check that the logic is set up to consistently clear the index before recreating it & include that code here.

Also, once this PR is brought in, I can go ahead and test the related [la-metro-dashboard/pull/72](https://github.com/datamade/la-metro-dashboard/pull/72) PR.

## Testing Instructions

 * run `docker-compose run --rm app python manage.py update_index --remove` and make sure the command runs successfully

Handles #623 
