### PR TITLE
Re-order facets

### DIFF
--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -41,6 +41,7 @@
             {% endif %}
 
             <!---------- REPORT DETAILS ------------>
+            <br />
             <h5>Report Details</h5>
             <!-- Meetings -->
             {% if facets.fields.sponsorships %}
@@ -86,6 +87,7 @@
             {% endwith %}
 
             <!---------- REPORT KEYWORDS ------------>
+            <br />
             <h5>Report Keywords</h5>
             <!-- Lines / Ways -->
             {% if facets.fields.lines_and_ways %}

--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -40,16 +40,42 @@
                 </p>
             {% endif %}
 
-            <!-- Legislation Status -->
-            {% with facet_name='inferred_status' facet_label='Status' item_list=facets.fields.inferred_status selected_list=selected_facets.inferred_status %}
-                {% include 'partials/search_filter.html' %}
-            {% endwith %}
+            <!---------- REPORT DETAILS ------------>
+            <h5>Report Details</h5>
+            <!-- Meetings -->
+            {% if facets.fields.sponsorships %}
+                {% with facet_name='sponsorships' facet_label='Meeting' item_list=facets.fields.sponsorships selected_list=selected_facets.sponsorships %}
+                    {% include 'partials/search_filter.html' %}
+                {% endwith %}
+            {% endif %}
+
+            <!-- Significant Date -->
+            {% if facets.fields.significant_date %}
+                {% with facet_name='significant_date' facet_label='Significant Date' item_list=facets.fields.significant_date selected_list=selected_facets.significant_date %}
+                    {% include 'partials/search_filter.html' %}
+                {% endwith %}
+            {% endif %}
 
             <!-- Legislation Type -->
             {% with facet_name='bill_type' facet_label='Legislation Type' item_list=facets.fields.bill_type selected_list=selected_facets.bill_type %}
                 {% include 'partials/search_filter.html' %}
             {% endwith %}
 
+
+            <!-- Motion By -->
+            {% if facets.fields.motion_by %}
+                {% with facet_name='motion_by' facet_label='Motion By' item_list=facets.fields.motion_by selected_list=selected_facets.motion_by %}
+                    {% include 'partials/search_filter.html' %}
+                {% endwith %}
+            {% endif %}
+
+            <!-- Legislation Status -->
+            {% with facet_name='inferred_status' facet_label='Status' item_list=facets.fields.inferred_status selected_list=selected_facets.inferred_status %}
+                {% include 'partials/search_filter.html' %}
+            {% endwith %}
+
+            <!---------- REPORT KEYWORDS ------------>
+            <h5>Report Keywords</h5>
             <!-- Lines / Ways -->
             {% if facets.fields.lines_and_ways %}
                 {% with facet_name='lines_and_ways' facet_label='Lines / Ways' item_list=facets.fields.lines_and_ways selected_list=selected_facets.lines_and_ways %}
@@ -71,9 +97,9 @@
                 {% endwith %}
             {% endif %}
 
-            <!-- Metro Location -->
-            {% if facets.fields.metro_location %}
-                {% with facet_name='metro_location' facet_label='Metro Location' item_list=facets.fields.metro_location selected_list=selected_facets.metro_location %}
+            <!-- Plan, Program, or Policy -->
+            {% if facets.fields.plan_program_policy %}
+                {% with facet_name='plan_program_policy' facet_label='Plan, Program, or Policy' item_list=facets.fields.plan_program_policy selected_list=selected_facets.plan_program_policy %}
                     {% include 'partials/search_filter.html' %}
                 {% endwith %}
             {% endif %}
@@ -85,16 +111,9 @@
                 {% endwith %}
             {% endif %}
 
-            <!-- Significant Date -->
-            {% if facets.fields.significant_date %}
-                {% with facet_name='significant_date' facet_label='Significant Date' item_list=facets.fields.significant_date selected_list=selected_facets.significant_date %}
-                    {% include 'partials/search_filter.html' %}
-                {% endwith %}
-            {% endif %}
-
-            <!-- Motion By -->
-            {% if facets.fields.motion_by %}
-                {% with facet_name='motion_by' facet_label='Motion By' item_list=facets.fields.motion_by selected_list=selected_facets.motion_by %}
+            <!-- Metro Location -->
+            {% if facets.fields.metro_location %}
+                {% with facet_name='metro_location' facet_label='Metro Location' item_list=facets.fields.metro_location selected_list=selected_facets.metro_location %}
                     {% include 'partials/search_filter.html' %}
                 {% endwith %}
             {% endif %}
@@ -102,32 +121,6 @@
             <!-- Subject -->
             {% if facets.fields.topics %}
                 {% with facet_name='topics' facet_label='Subject' item_list=facets.fields.topics selected_list=selected_facets.topics %}
-                    {% include 'partials/search_filter.html' %}
-                {% endwith %}
-            {% endif %}
-
-            <!-- Legislative Session -->
-            {% if facets.fields.legislative_session %}
-                <!-- only show leg sesh filter pane if there is more than one leg sesh to select from -->
-                {% if facets.fields.legislative_session|length > 1 %}
-
-                    {% with facet_name='legislative_session' facet_label='Legislative Session' item_list=facets.fields.legislative_session selected_list=selected_facets.legislative_session %}
-                        {% include 'partials/search_filter.html' %}
-                    {% endwith %}
-
-                {% endif %}
-            {% endif %}
-
-            <!-- Plan, Program, or Policy -->
-            {% if facets.fields.plan_program_policy %}
-                {% with facet_name='plan_program_policy' facet_label='Plan, Program, or Policy' item_list=facets.fields.plan_program_policy selected_list=selected_facets.plan_program_policy %}
-                    {% include 'partials/search_filter.html' %}
-                {% endwith %}
-            {% endif %}
-
-            <!-- Meetings -->
-            {% if facets.fields.sponsorships %}
-                {% with facet_name='sponsorships' facet_label='Meeting' item_list=facets.fields.sponsorships selected_list=selected_facets.sponsorships %}
                     {% include 'partials/search_filter.html' %}
                 {% endwith %}
             {% endif %}

--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -56,11 +56,22 @@
                 {% endwith %}
             {% endif %}
 
+            <!-- Legislative Session -->
+            {% if facets.fields.legislative_session %}
+                <!-- only show leg sesh filter pane if there is more than one leg sesh to select from -->
+                {% if facets.fields.legislative_session|length > 1 %}
+
+                    {% with facet_name='legislative_session' facet_label='Legislative Session' item_list=facets.fields.legislative_session selected_list=selected_facets.legislative_session %}
+                        {% include 'partials/search_filter.html' %}
+                    {% endwith %}
+
+                {% endif %}
+            {% endif %}
+
             <!-- Legislation Type -->
             {% with facet_name='bill_type' facet_label='Legislation Type' item_list=facets.fields.bill_type selected_list=selected_facets.bill_type %}
                 {% include 'partials/search_filter.html' %}
             {% endwith %}
-
 
             <!-- Motion By -->
             {% if facets.fields.motion_by %}


### PR DESCRIPTION
## Overview

This PR changes the order of the facets on the search results page.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

We have a 'Significant Date' facet that doesn't seem to be showing up & isn't in Shelly's list of facets. Is this facet still relevant?

## Testing Instructions

 * Run the app locally and do a simple search
 * Verify that the left side of the search results page has the facets ordered in the way Shelly described:

> **Report Details**
> Meeting
> Fiscal year
> Report Type
> Motion By
> Status
> 
> **Report Keywords**
> Lines/ways
> Phase
> Project
> Plan, Program, or Policy
> Geographic location
> Metro Location
> Subject

 * Also verify that the sidebar looks the same on any board report detail page

Handles #702 
