### PR TITLE
fix text overlap on mobile issue

### DIFF
--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -45,6 +45,7 @@ h1, .h1 {
     background-repeat: no-repeat;
     background-position: center center;
     min-height: 380px;
+    height: unset;
 }
 
 #section-intro {

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block full_content %}
-    <div id="section-photo">
+    <div id="section-photo" class="container-fluid">
         <div class="row">
             <div class='col-sm-10 col-sm-offset-1'>
                 <span class="hidden-xs hidden-sm"><br/><br/></span>

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -7,7 +7,8 @@
 {% endblock %}
 
 {% block full_content %}
-    <div class="container-fluid" id="section-photo">
+<div class="contianer">
+    <div id="section-photo">
         <div class="row-fluid">
             <div class='col-sm-10 col-sm-offset-1'>
                 <span class="hidden-xs hidden-sm"><br/><br/></span>
@@ -100,6 +101,7 @@
             </div>
         </div>
     </div>
+</div>
 
 {% endblock %}
 

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -8,7 +8,7 @@
 
 {% block full_content %}
     <div id="section-photo">
-        <div class="row-fluid">
+        <div class="row">
             <div class='col-sm-10 col-sm-offset-1'>
                 <span class="hidden-xs hidden-sm"><br/><br/></span>
                     <h1 class="home-header">Los Angeles County Metropolitan Transportation Authority</h1>

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block full_content %}
-<div class="contianer">
+<div class="container">
     <div id="section-photo">
         <div class="row-fluid">
             <div class='col-sm-10 col-sm-offset-1'>

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -7,7 +7,6 @@
 {% endblock %}
 
 {% block full_content %}
-<div class="container">
     <div id="section-photo">
         <div class="row-fluid">
             <div class='col-sm-10 col-sm-offset-1'>
@@ -101,7 +100,6 @@
             </div>
         </div>
     </div>
-</div>
 
 {% endblock %}
 


### PR DESCRIPTION
## Overview

This PR addresses an issue on mobile devices where the text under the home page search bar overlaps with the heading for the next section.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo
<img width="516" alt="Screen Shot 2021-04-20 at 1 30 10 PM" src="https://user-images.githubusercontent.com/48227264/115446267-8f100180-a1dc-11eb-8261-8eb2b3ef9c3c.png">

### Notes
In resolving the text overlap issue, I introduced an issue where the top margin of the `h1` that reads "Los Angeles County Metropolitan Transportation Authority" It looks like we're using Bootstrap 2 in this project, and the classes I would usually use to remove that margin are unavailable in this version of Bootstrap. I'd be interested in any ideas around how to remove this whitespace.

This is no longer an issue as of second review request.

## Testing Instructions

 * run the app locally and use your browser's device toolbar to toggle mobile view
 * make sure none of the text on the home page overlaps, and in particular that the text on the background image at the very top of the page doesn't overflow its bounds

Handles #674  
