### PR TITLE
Apply temporary patch to topic highlighting for board reports with no subject

### DIFF
--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -205,6 +205,9 @@ def hits_first(context, topics, selected_facets):
     Return array of topics, such that topics matching a selected facet or the
     search term are returned first, followed by the remaining tags in ABC order.
     '''
+    if isinstance(topics, list):
+        return topics
+
     topic_names = topics.values_list('name', flat=True)
 
     # context['query'] looks like "(token) AND (token) AND (token)". Sometimes,


### PR DESCRIPTION
## Overview

See title.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

This is a relatively rare instance currently breaking the search, so I opted for a quick fix here. Will leave to Metro whether to prioritize.

## Testing Instructions

 * Confirm CI passes.
 * Once this is merged and deployed to staging, navigate to https://lametro-upgrade.datamade.us/search/?q=2019-0712&search-all=on and confirm the results render.

Connects #722
