### PR TITLE
Patch actions_and_agendas to handle events without related organizations

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -235,7 +235,7 @@ class LAMetroBill(Bill, SourcesMixin):
                 # If a corresponding org does not exist, e.g., in the case of
                 # appearing on the agenda of a public hearing, do not return an
                 # organization.
-                org = None
+                org = event.participants.first()
 
             event_dict = {
                 'date': event.start_time.date(),

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -226,12 +226,20 @@ class LAMetroBill(Bill, SourcesMixin):
             data.append(action_dict)
 
         for event in events:
-            # Use a description of "SCHEDULED"
-            org = LAMetroOrganization.objects.get(id=event.participants.first().organization_id)
+            try:
+                # Attempt to return Metro org object.
+                org = LAMetroOrganization.objects.get(
+                    id=event.participants.first().organization_id
+                )
+            except LAMetroOrganization.DoesNotExist:
+                # If a corresponding org does not exist, e.g., in the case of
+                # appearing on the agenda of a public hearing, do not return an
+                # organization.
+                org = None
 
             event_dict = {
                 'date': event.start_time.date(),
-                'description': 'SCHEDULED',
+                'description': 'SCHEDULED',  # Use a description of "SCHEDULED"
                 'event': event,
                 'organization': org
             }

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -233,8 +233,8 @@ class LAMetroBill(Bill, SourcesMixin):
                 )
             except LAMetroOrganization.DoesNotExist:
                 # If a corresponding org does not exist, e.g., in the case of
-                # appearing on the agenda of a public hearing, do not return an
-                # organization.
+                # appearing on the agenda of a public hearing, return the event
+                # participant object.
                 org = event.participants.first()
 
             event_dict = {

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -29,11 +29,7 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         return None
 
     def prepare_sponsorships(self, obj):
-        orgs_list = [
-            action['organization'].name
-            for action in obj.actions_and_agendas
-            if action['organization']
-        ]
+        orgs_list = [action['organization'].name for action in obj.actions_and_agendas]
         return set(orgs_list)
 
     def prepare_sort_name(self, obj):

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -29,7 +29,11 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         return None
 
     def prepare_sponsorships(self, obj):
-        orgs_list = [action['organization'].name for action in obj.actions_and_agendas]
+        orgs_list = [
+            action['organization'].name
+            for action in obj.actions_and_agendas
+            if action['organization']
+        ]
         return set(orgs_list)
 
     def prepare_sort_name(self, obj):

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -146,8 +146,16 @@ def test_last_action_date_has_already_occurred(bill, event):
     # Assert the last action matches the event that has already occurred.
     assert last_action_date == two_weeks_ago.date()
 
+@pytest.mark.parametrize('event_has_related_org', [True, False])
 @pytest.mark.django_db
-def test_actions_and_agendas(bill, event, bill_action, event_agenda_item, caplog, event_related_entity):
+def test_actions_and_agendas(bill,
+                             bill_action,
+                             event,
+                             event_agenda_item,
+                             event_related_entity,
+                             caplog,
+                             event_has_related_org):
+
     caplog.set_level(logging.WARNING)
 
     # create a bill with no actions or agendas and confirm actions and agendas
@@ -190,7 +198,17 @@ def test_actions_and_agendas(bill, event, bill_action, event_agenda_item, caplog
     assert expected_action['description'] == some_action.description
 
     # add bill to event agenda and confirm it appears
-    some_agenda_item = event_agenda_item.build(event=some_event)
+    if event_has_related_org:
+        some_agenda_item = event_agenda_item.build(event=some_event)
+
+    else:
+        some_event = event.build(name='Public Hearing',
+                                 start_date='{} 12:00'.format(action_date),
+                                 id='ocd-event/public-hearing')
+
+        EventParticipant.objects.create(event=some_event)
+        some_agenda_item = event_agenda_item.build(event=some_event)
+
     event_related_entity.build(agenda_item=some_agenda_item, bill=some_bill)
 
     aaa = some_bill.actions_and_agendas
@@ -199,7 +217,11 @@ def test_actions_and_agendas(bill, event, bill_action, event_agenda_item, caplog
 
     expected_agenda = aaa[0]  # agenda should appear first
 
-    assert expected_agenda['organization'] == action_org
+    if event_has_related_org:
+        assert expected_agenda['organization'] == action_org
+    else:
+        assert expected_agenda['organization'] == None
+
     assert expected_agenda['event'] == some_event
     assert expected_agenda['date'] == datetime.strptime(some_action.date, '%Y-%m-%d')\
                                               .date()

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -206,7 +206,7 @@ def test_actions_and_agendas(bill,
                                  start_date='{} 12:00'.format(action_date),
                                  id='ocd-event/public-hearing')
 
-        EventParticipant.objects.create(event=some_event)
+        some_participant = EventParticipant.objects.create(event=some_event)
         some_agenda_item = event_agenda_item.build(event=some_event)
 
     event_related_entity.build(agenda_item=some_agenda_item, bill=some_bill)
@@ -220,7 +220,7 @@ def test_actions_and_agendas(bill,
     if event_has_related_org:
         assert expected_agenda['organization'] == action_org
     else:
-        assert expected_agenda['organization'] == None
+        assert expected_agenda['organization'] == some_participant
 
     assert expected_agenda['event'] == some_event
     assert expected_agenda['date'] == datetime.strptime(some_action.date, '%Y-%m-%d')\

--- a/tests/test_solr_prep.py
+++ b/tests/test_solr_prep.py
@@ -1,6 +1,8 @@
 import pytest
 from datetime import datetime
 
+from opencivicdata.legislative.models import EventParticipant
+
 from lametro.search_indexes import LAMetroBillIndex
 
 @pytest.mark.parametrize('session_identifier,prepared_session', [
@@ -34,12 +36,14 @@ def test_legislative_session(bill,
 def test_sponsorships(bill, 
                       metro_organization,
                       event,
+                      event_related_entity,
                       mocker):
     bill = bill.build()
 
     org1 = metro_organization.build()
     org2 = metro_organization.build()
     event1 = event.build()
+    event1_participant = EventParticipant.objects.create(event=event1, name='Public Hearing')
     actions_and_agendas = [
         {
             'date': datetime.now(),
@@ -63,7 +67,7 @@ def test_sponsorships(bill,
             'date': datetime.now(),
             'description': 'SCHEDULED',
             'event': event1,
-            'organization': None
+            'organization': event1_participant
         }
     ]
     mock_actions_and_agendas = mocker.patch('lametro.models.LAMetroBill.actions_and_agendas',\
@@ -73,4 +77,4 @@ def test_sponsorships(bill,
     index = LAMetroBillIndex()
     indexed_data = index.prepare(bill)
 
-    assert indexed_data['sponsorships'] == {org1.name, org2.name}
+    assert indexed_data['sponsorships'] == {org1.name, org2.name, 'Public Hearing'}

--- a/tests/test_solr_prep.py
+++ b/tests/test_solr_prep.py
@@ -58,6 +58,12 @@ def test_sponsorships(bill,
             'description': 'org2 descripton',
             'event': event1,
             'organization': org2
+        },
+        {
+            'date': datetime.now(),
+            'description': 'SCHEDULED',
+            'event': event1,
+            'organization': None
         }
     ]
     mock_actions_and_agendas = mocker.patch('lametro.models.LAMetroBill.actions_and_agendas',\


### PR DESCRIPTION
## Overview

Some events are not associated with an organization. This PR updates `actions_and_agendas` to try to return an `LAMetroOrganization` object, falling back to the event related entity if one does not exist.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

I maintained the event participant fallback because we still want to be able to filter by meetings that aren't associated with a body, such as public hearings, in the search. If we didn't fall back, those meetings would not be available as facets.

## Testing Instructions

 * Visit https://lametro-upgrade.datamade.us/board-report/2020-0522/ and confirm the page loads, and the actions and agendas are rendered as expected.
 * Confirm CI passes.
 * Review the code.
 
Connects #712 
