### PR TITLE
Patch label display on Firefox

### DIFF
--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -159,6 +159,7 @@ strong.match-group {
 /* Labels for statues */
 .label {
     padding: .25em .6em .25em;
+    display: inline-block;
 }
 
 .label-teal { background-color: #49A6AB; }


### PR DESCRIPTION
## Overview

This PR switches labels to `inline-block` so label containers don't wrap lines if the text is forced onto a new line.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

![metro](https://user-images.githubusercontent.com/12176173/120663144-64f26600-c44f-11eb-8e56-8f55c36ddc58.gif)

## Testing Instructions

 * See demo GIF. I manually returned events from today's meetings to test this in Firefox.

Handles #694 
