### PR TITLE
Revert faceting patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,3 @@ debug.log
 
 *.csv
 .gnupg/
-
-lametro/secrets.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,8 +61,6 @@ services:
       DATABASE_URL: 'postgis://postgres:@postgres/lametro'
       SHARED_DB: "True"
     command: sh -c 'pupa update --rpm=600 lametro people && pupa update --rpm=600 lametro bills window=30 && pupa update --rpm=600 lametro events'
-    volumes:
-      - ./lametro/secrets.py:/app/lametro/secrets.py
 
 volumes:
   lametro-solr-data:

--- a/lametro/management/commands/refresh_guid.py
+++ b/lametro/management/commands/refresh_guid.py
@@ -68,7 +68,7 @@ class ClassificationMixin:
             'Subregion',
         ),
         'significant_date_exact': (
-            'Date',
+            'Dates',
         ),
         'motion_by_exact': (
             'Board Member',
@@ -77,7 +77,7 @@ class ClassificationMixin:
             'Plan',
             'Program',
             'Policy'
-        )
+        ),
     }
 
     @property

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -50,26 +50,13 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         )
 
     def prepare_legislative_session(self, obj):
-        aa = sorted(obj.actions_and_agendas, key=lambda i: i['date'],reverse=True)
-        agendas = [a for a in aa if a['description'] == 'SCHEDULED']
-        if len(aa) > 1:
-            if agendas:
-                action_date = agendas[0]['date']
-            else:
-                action_date = aa[0]['date']
+        start_year = obj.legislative_session.identifier
+        end_year = int(start_year) + 1
 
-            if action_date.month <= 6:
-                start_year = action_date.year - 1
-                end_year = action_date.year
-            else:
-                start_year = action_date.year
-                end_year = action_date.year + 1
+        session = '7/1/{start_year} to 6/30/{end_year}'.format(start_year=start_year,
+                                                               end_year=end_year)
 
-            session = '7/1/{start_year} to 6/30/{end_year}'.format(start_year=start_year,
-                                                                   end_year=end_year)
-            return session
-        return None
-
+        return session
 
     def prepare_topics(self, obj):
         return self._topics_from_classification(obj, 'topics_exact')

--- a/tests/test_solr_prep.py
+++ b/tests/test_solr_prep.py
@@ -1,100 +1,39 @@
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from opencivicdata.legislative.models import EventParticipant
 
 from lametro.search_indexes import LAMetroBillIndex
 
-@pytest.mark.parametrize('month', [6, 7])
-def test_legislative_session(bill, metro_organization, event, mocker, month):
+@pytest.mark.parametrize('session_identifier,prepared_session', [
+    ('2014', '7/1/2014 to 6/30/2015'),
+    ('2015', '7/1/2015 to 6/30/2016'),
+    ('2016', '7/1/2016 to 6/30/2017'),
+    ('2017', '7/1/2017 to 6/30/2018'),
+    ('2018', '7/1/2018 to 6/30/2019'),
+])
+def test_legislative_session(bill, 
+                             legislative_session,
+                             session_identifier,
+                             prepared_session):
     '''
     This test instantiates LAMetroBillIndex – a subclass of SearchIndex from
     Haystack, used for building the Solr index.
 
-    The test, then, calls the SearchIndex `prepare` function,
+    The test, then, calls the SearchIndex `prepare` function, 
     which returns a dict of prepped data.
     https://github.com/django-haystack/django-haystack/blob/4910ccb01c31d12bf22dcb000894eece6c26f74b/haystack/indexes.py#L198
     '''
-    org = metro_organization.build()
-    event = event.build()
-    bill = bill.build()
-
-    now = datetime.now()
-
-    # Create test actions and agendas
-    recent_action = {
-        'date': datetime(now.year, month, now.day),
-        'description': 'org2 descripton',
-        'event': event,
-        'organization': org
-    }
-    older_action = {
-        'date': datetime(now.year, month, now.day) - timedelta(days=365*2),
-        'description': 'org2 descripton',
-        'event': event,
-        'organization': org
-    }
-    recent_agenda = {
-        'date': datetime(now.year, month, now.day) - timedelta(days=365),
-        'description': 'SCHEDULED',
-        'event': event,
-        'organization': org
-    }
-    older_agenda = {
-        'date': datetime(now.year, month, now.day) - timedelta(days=365*3),
-        'description': 'SCHEDULED',
-        'event': event,
-        'organization': org
-    }
-
-    # Test indexed value when there are both actions and agendas
-    mock_actions_and_agendas = mocker.PropertyMock(
-        return_value=[recent_action, older_action, recent_agenda, older_agenda]
-    )
-
-    mocker.patch('lametro.models.LAMetroBill.actions_and_agendas', new_callable=mock_actions_and_agendas)
+    legislative_session.identifier = session_identifier
+    legislative_session.save()
+    bill = bill.build(legislative_session=legislative_session)
 
     index = LAMetroBillIndex()
-    expected_fmt = '7/1/{0} to 6/30/{1}'
-
     indexed_data = index.prepare(bill)
 
-    if month <= 6:
-        expected_value = expected_fmt.format(recent_agenda['date'].year - 1, recent_agenda['date'].year)
-    else:
-        expected_value = expected_fmt.format(recent_agenda['date'].year, recent_agenda['date'].year + 1)
+    assert indexed_data['legislative_session'] == prepared_session
 
-    assert indexed_data['legislative_session'] == expected_value
-
-    # Test indexed value when there are just actions
-    mock_actions_and_agendas = mocker.PropertyMock(
-        return_value=[recent_action, older_action]
-    )
-
-    mocker.patch('lametro.models.LAMetroBill.actions_and_agendas', new_callable=mock_actions_and_agendas)
-
-    indexed_data = index.prepare(bill)
-
-    if month <= 6:
-        expected_value = expected_fmt.format(recent_action['date'].year - 1, recent_action['date'].year)
-    else:
-        expected_value = expected_fmt.format(recent_action['date'].year, recent_action['date'].year + 1)
-
-    assert indexed_data['legislative_session'] == expected_value
-
-    # Test indexed value when there are neither actions nor agendas
-    mock_actions_and_agendas = mocker.PropertyMock(
-        return_value=[]
-    )
-
-    mocker.patch('lametro.models.LAMetroBill.actions_and_agendas', new_callable=mock_actions_and_agendas)
-
-    indexed_data = index.prepare(bill)
-
-    assert not indexed_data['legislative_session']
-
-
-def test_sponsorships(bill,
+def test_sponsorships(bill, 
                       metro_organization,
                       event,
                       event_related_entity,


### PR DESCRIPTION
## Overview

This reverts commit 5caa4e4e828016bc6522cccad78b95723eaaf22f, reversing changes made to 4d40d9d4c126b4bc1d10b15f6de4b0f3e3b0e2d8.

I'm reverting these changes because https://github.com/datamade/la-metro-dashboard/issues/78 blocks us from fully vetting them, and we need to make a few high priority changes in the meantime.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs
