### PR TITLE
Fix significant date and fiscal year facets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ debug.log
 
 *.csv
 .gnupg/
+
+lametro/secrets.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,8 @@ services:
       DATABASE_URL: 'postgis://postgres:@postgres/lametro'
       SHARED_DB: "True"
     command: sh -c 'pupa update --rpm=600 lametro people && pupa update --rpm=600 lametro bills window=30 && pupa update --rpm=600 lametro events'
+    volumes:
+      - ./lametro/secrets.py:/app/lametro/secrets.py
 
 volumes:
   lametro-solr-data:

--- a/lametro/management/commands/refresh_guid.py
+++ b/lametro/management/commands/refresh_guid.py
@@ -68,7 +68,7 @@ class ClassificationMixin:
             'Subregion',
         ),
         'significant_date_exact': (
-            'Dates',
+            'Date',
         ),
         'motion_by_exact': (
             'Board Member',
@@ -77,7 +77,7 @@ class ClassificationMixin:
             'Plan',
             'Program',
             'Policy'
-        ),
+        )
     }
 
     @property

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -50,13 +50,26 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         )
 
     def prepare_legislative_session(self, obj):
-        start_year = obj.legislative_session.identifier
-        end_year = int(start_year) + 1
+        aa = sorted(obj.actions_and_agendas, key=lambda i: i['date'],reverse=True)
+        agendas = [a for a in aa if a['description'] == 'SCHEDULED']
+        if len(aa) > 1:
+            if agendas:
+                action_date = agendas[0]['date']
+            else:
+                action_date = aa[0]['date']
 
-        session = '7/1/{start_year} to 6/30/{end_year}'.format(start_year=start_year,
-                                                               end_year=end_year)
+            if action_date.month <= 6:
+                start_year = action_date.year - 1
+                end_year = action_date.year
+            else:
+                start_year = action_date.year
+                end_year = action_date.year + 1
 
-        return session
+            session = '7/1/{start_year} to 6/30/{end_year}'.format(start_year=start_year,
+                                                                   end_year=end_year)
+            return session
+        return None
+
 
     def prepare_topics(self, obj):
         return self._topics_from_classification(obj, 'topics_exact')


### PR DESCRIPTION
## Overview

This reverts commit 72f57924b55be6c0aedaa0647035ae0baa258b0e, reversing changes made to 5caa4e4e828016bc6522cccad78b95723eaaf22f.

This PR is effectively equal to #727

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Merge to deploy to staging server
 * Build and push staging app image to Dockerhub
 * Run `refresh_guid` from the staging dashboard
 * Wait for an `hourly_processing` job to run at the 55 past the hour, so all bills are reindexed
 * Visit the staging site and spot check significant date and fiscal year facets

Handles #716 
Handles #370 