### PR TITLE
Update recap link, handles #748

### DIFF
--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -221,7 +221,7 @@
                             {% if 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
                             <h4>Minutes</h4>
                             <p>
-                                <a href="https://www.metro.net/about/board/recap-actions/" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> View Recap</a>
+                                <a href="http://boardarchives.metro.net/recaps/" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> View Recap</a>
                                 </br>
                             </p>
                             {% endif %}

--- a/lametro/templates/partials/past_event_day.html
+++ b/lametro/templates/partials/past_event_day.html
@@ -57,7 +57,7 @@
     <div class="col-xs-1">
         {% if 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
         <p>
-            <a href="https://www.metro.net/about/board/recap-actions/" target="_blank">Recap</a>
+            <a href="http://boardarchives.metro.net/recaps/" target="_blank">Recap</a>
             </br>
         </p>
         {% endif %}


### PR DESCRIPTION
## Overview

See title. It also reduces the default event scrape to 30 days, so it can be run more quickly.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Rebuild your scraper image to confirm you've got the most recent changes: `docker-compose build scrapers` 
 * Grab future events, as well as events updated in the past 60 days: `docker-compose run --rm scrapers pupa update lametro events window=60 --rpm=0`
 * View the event listing page, and scroll down to a past event with audio and recap links. Click on the recap link and confirm it leads you to http://boardarchives.metro.net/recaps/.

![Screen Shot 2021-09-07 at 11 48 58 AM](https://user-images.githubusercontent.com/12176173/132382118-10207f07-de5d-4066-b300-ca3f057d1b6b.png)

 * Click into the detail page of the meeting whose recap link you just clicked. Click on the recap link there, too, and confirm it leads you to http://boardarchives.metro.net/recaps/.

![Screen Shot 2021-09-07 at 11 49 21 AM](https://user-images.githubusercontent.com/12176173/132382137-c030ae17-ee9a-4ef9-976b-6b7b32819720.png)
 
Handles #748
