### PR TITLE
Update search page href, fixes #747

### DIFF
--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -282,7 +282,7 @@
                     <ul class="pagination">
                         {% if page.has_previous %}
                             <li>
-                                <a href="?{{ q_filters }}&amp;page={{ page.previous_page_number }}" aria-label="Previous"><span aria-hidden="true">&laquo; Previous</span></a>
+                                <a href="/search/?{{ q_filters }}&amp;page={{ page.previous_page_number }}" aria-label="Previous"><span aria-hidden="true">&laquo; Previous</span></a>
                             </li>
                         {% else %}
                             <li class="disabled">
@@ -292,7 +292,7 @@
 
                         {% if page.has_next %}
                             <li>
-                                <a href="?{{ q_filters }}&amp;page={{ page.next_page_number }}" aria-label="Next"><span aria-hidden="true">Next &raquo;</span></a>
+                                <a href="/search/?{{ q_filters }}&amp;page={{ page.next_page_number }}" aria-label="Next"><span aria-hidden="true">Next &raquo;</span></a>
                             </li>
                         {% else %}
                             <li class="disabled">


### PR DESCRIPTION
## Overview

This PR updates the previous and next page links on the search page such that any page of search results can be viewed without error.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

![search_fix](https://user-images.githubusercontent.com/12176173/132910837-c5f44cd9-a11c-485a-b46e-877dd503612a.gif)

## Testing Instructions

 * Tested locally, as per demo.
 * If this change makes sense, let's test on staging.

Handles #747 