### PR TITLE
Only display packet links if a packet is available, fixes #756

### DIFF
--- a/lametro/templates/partials/related_bills.html
+++ b/lametro/templates/partials/related_bills.html
@@ -18,7 +18,7 @@
         <td>
           <a href='/board-report/{{ associated_bill.slug }}/' target="_blank">View</a>
         </td>
-        <td><a href={% if associated_bill.packet.url %}"{{associated_bill.packet.url}}"{% else %}"{{associated_bill.board_report.url}}"{% endif %}>Download</a></td>
+        <td><a href={% if associated_bill.packet.is_ready %}"{{associated_bill.packet.url}}"{% else %}"{{associated_bill.board_report.url}}"{% endif %}>Download</a></td>
       </tr>
       {% endwith %}
   {% endfor %}


### PR DESCRIPTION
## Overview

This PR updates the conditional determining whether to display a packet link or fall back to a link to the board report to use [the `is_ready` method](https://github.com/datamade/la-metro-councilmatic/blob/77c19686281d38b4abbc9375da0198fd875ca148/lametro/models.py#L809) of a packet. Using `url` will always show the packet link, because [`url` is set on `save()`](https://github.com/datamade/la-metro-councilmatic/blob/77c19686281d38b4abbc9375da0198fd875ca148/lametro/models.py#L806). By contrast, `is_ready()` will only show the packet if it actually exists.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

@hancush will do this after getting PR approval.

 * Deploy to staging
 * View a recent event with an agenda, e.g., https://lametro-upgrade.datamade.us/event/planning-and-programming-committee-44279664d25e/, and confirm the "View" link in the related board reports listing downloads the board report

Handles #756 
