### PR TITLE
Add remote meeting banner on home and event/s pages

### DIFF
--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -5,6 +5,17 @@
 {% load staticfiles %}
 {% block title %}{{event.name}}{% endblock %}
 {% block content %}
+    <div class="container-fluid">
+        <br />
+        <div class="alert alert-danger" role="alert">
+            <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+            * Consistent with AB361, Board and Committee Meetings will continue to meet virtually so long as there’s a declared state of emergency. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Click here</a>.
+        </div>
+        <div class="alert alert-danger" role="alert">
+            <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+            De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí</a>.
+        </div>
+    </div>
 
     <div class="row-fluid">
         <div class="col-sm-12">

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -5,17 +5,7 @@
 {% load staticfiles %}
 {% block title %}{{event.name}}{% endblock %}
 {% block content %}
-    <div class="container-fluid">
-        <br />
-        <div class="alert alert-danger" role="alert">
-            <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-            * Consistent with AB361, Board and Committee Meetings will continue to meet virtually so long as there’s a declared state of emergency. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Click here</a>.
-        </div>
-        <div class="alert alert-danger" role="alert">
-            <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-            * De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí</a>.
-        </div>
-    </div>
+    {% include 'partials/banner.html' %}
 
     <div class="row-fluid">
         <div class="col-sm-12">

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -13,7 +13,7 @@
         </div>
         <div class="alert alert-danger" role="alert">
             <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-            De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí</a>.
+            * De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí</a>.
         </div>
     </div>
 

--- a/lametro/templates/lametro/events.html
+++ b/lametro/templates/lametro/events.html
@@ -15,7 +15,7 @@
         </div>
         <div class="alert alert-danger" role="alert">
             <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-            De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí</a>.
+            * De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí</a>.
         </div>
     </div>
     <div class="row-fluid">

--- a/lametro/templates/lametro/events.html
+++ b/lametro/templates/lametro/events.html
@@ -7,6 +7,17 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.4.1/css/bootstrap-datepicker3.css"/>
 {% endblock %}
 {% block content %}
+    <div class="container-fluid">
+        <br />
+        <div class="alert alert-danger" role="alert">
+            <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+            * Consistent with AB361, Board and Committee Meetings will continue to meet virtually so long as there’s a declared state of emergency. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Click here</a>.
+        </div>
+        <div class="alert alert-danger" role="alert">
+            <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+            De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí</a>.
+        </div>
+    </div>
     <div class="row-fluid">
         <div class="col-sm-9 no-pad-mobile">
             <br/><br class="non-mobile-only"/>

--- a/lametro/templates/lametro/events.html
+++ b/lametro/templates/lametro/events.html
@@ -7,17 +7,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.4.1/css/bootstrap-datepicker3.css"/>
 {% endblock %}
 {% block content %}
-    <div class="container-fluid">
-        <br />
-        <div class="alert alert-danger" role="alert">
-            <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-            * Consistent with AB361, Board and Committee Meetings will continue to meet virtually so long as there’s a declared state of emergency. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Click here</a>.
-        </div>
-        <div class="alert alert-danger" role="alert">
-            <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-            * De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí</a>.
-        </div>
-    </div>
+    {% include 'partials/banner.html' %}
     <div class="row-fluid">
         <div class="col-sm-9 no-pad-mobile">
             <br/><br class="non-mobile-only"/>

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -7,6 +7,17 @@
 {% endblock %}
 
 {% block full_content %}
+    <div class="container-fluid">
+        <br />
+        <div class="alert alert-danger" role="alert">
+            <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+            * Consistent with AB361, Board and Committee Meetings will continue to meet virtually so long as there’s a declared state of emergency. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Click here</a>.
+        </div>
+        <div class="alert alert-danger" role="alert">
+            <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+            De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí</a>.
+        </div>
+    </div>
     <div id="section-photo" class="container-fluid">
         <div class="row">
             <div class='col-sm-10 col-sm-offset-1'>

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -15,7 +15,7 @@
         </div>
         <div class="alert alert-danger" role="alert">
             <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-            De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí</a>.
+            * De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí</a>.
         </div>
     </div>
     <div id="section-photo" class="container-fluid">

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -7,17 +7,7 @@
 {% endblock %}
 
 {% block full_content %}
-    <div class="container-fluid">
-        <br />
-        <div class="alert alert-danger" role="alert">
-            <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-            * Consistent with AB361, Board and Committee Meetings will continue to meet virtually so long as there’s a declared state of emergency. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Click here</a>.
-        </div>
-        <div class="alert alert-danger" role="alert">
-            <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-            * De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí</a>.
-        </div>
-    </div>
+    {% include 'partials/banner.html' %}
     <div id="section-photo" class="container-fluid">
         <div class="row">
             <div class='col-sm-10 col-sm-offset-1'>

--- a/lametro/templates/partials/banner.html
+++ b/lametro/templates/partials/banner.html
@@ -1,0 +1,11 @@
+<div class="container-fluid">
+    <br />
+    <div class="alert alert-danger" role="alert">
+        <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+        * Consistent with AB361, Board and Committee Meetings will continue to meet virtually so long as there’s a declared state of emergency. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Click here</a>.
+    </div>
+    <div class="alert alert-danger" role="alert">
+        <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+        * De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí</a>.
+    </div>
+</div>

--- a/lametro/templates/partials/banner.html
+++ b/lametro/templates/partials/banner.html
@@ -2,10 +2,10 @@
     <br />
     <div class="alert alert-danger" role="alert">
         <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-        * Consistent with AB361, Board and Committee Meetings will continue to meet virtually so long as there’s a declared state of emergency. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Click here</a>.
+        * Consistent with AB361, Board and Committee Meetings will continue to meet virtually so long as there’s a declared state of emergency. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Click here &raquo;</a>
     </div>
     <div class="alert alert-danger" role="alert">
         <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-        * De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí</a>.
+        * De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí &raquo;</a>
     </div>
 </div>


### PR DESCRIPTION
## Overview

This PR adds English and Spanish language banners on the Home, Event list, and Event detail pages about remote meetings during a state of emergency.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo
Home page:
<img width="1339" alt="Screen Shot 2021-09-27 at 2 24 10 PM" src="https://user-images.githubusercontent.com/48227264/134974260-1038a173-5c59-4dc3-8d3d-7c875e131c2f.png">

Event list:
<img width="1338" alt="Screen Shot 2021-09-27 at 2 41 38 PM" src="https://user-images.githubusercontent.com/48227264/134974270-ba91dba2-ef2a-4b4a-8e65-218ad0f8aff7.png">

Event detail:
<img width="1338" alt="Screen Shot 2021-09-27 at 2 41 46 PM" src="https://user-images.githubusercontent.com/48227264/134974272-836d51be-d4a8-4d14-a6cc-c4a4eaabde39.png">

### Notes

In the issue description, the English text starts with an asterisk. I wasn't sure if that was intended as it wasn't included in the Spanish text, so I omitted the asterisks, but I will post a quick question in the issue thread to double check this.

## Testing Instructions

 * Go to the home, event list, and event detail pages and check the banners, the banner text, and the links. Links should go here: https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361 

Handles #760 
