### PR TITLE
Point app at more powerful merger

### DIFF
--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -118,7 +118,7 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
-MERGER_BASE_URL = 'https://metro-pdf-merger.datamade.us'
+MERGER_BASE_URL = 'https://metro-pdf-merger-upgrade.datamade.us'
 # MERGER_BASE_URL = 'http://0.0.0.0:5000'
 
 PIC_BASE_URL = 'https://pic.datamade.us/lametro/document/'


### PR DESCRIPTION
## Overview

This PR updates `MERGER_BASE_URL`, in order to direct app requests for merged documents as well as dashboard pings to the merger to create packets at the freshly deployed and more powerful merger server.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * N/A

Connects #738 
