### PR TITLE
Sanitize queries for Solr, connects #732

### DIFF
--- a/lametro/forms.py
+++ b/lametro/forms.py
@@ -27,6 +27,25 @@ class LAMetroCouncilmaticSearchForm(CouncilmaticSearchForm):
 
         super(LAMetroCouncilmaticSearchForm, self).__init__(*args, **kwargs)
 
+    def clean_q(self):
+        q = self.cleaned_data['q']
+
+        # Close open quotes
+        if q.count('"') % 2:
+            q += '"'
+
+        # Escape reserved characters
+        reserved_characters = '''|&*/\!{[]}~-+'()^:'''
+
+        for char in reserved_characters:
+            q = q.replace(char, '\{}'.format(char))
+
+        # Downcase boolean operators
+        for op in ('OR', 'AND'):
+            q = q.replace(op, op.lower())
+
+        return q
+
     def _full_text_search(self, sqs):
         report_filter = SQ()
         attachment_filter = SQ()


### PR DESCRIPTION
## Overview

This PR adds a `clean_q` method to the search form that:

- Closes open quotes (because we want to retain the ability to search for phrases, whereas escaping double quotes would take that away)
- Escapes [other characters reserved by Solr](https://solr.apache.org/guide/7_3/the-standard-query-parser.html)
- Downcases AND/OR if they appear at the end of a query, as it confuses Solr to see an uppercase Boolean operator if there isn't another term after it.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Review the code and confirm it makes sense.
 * After review/approval, I'll merge to deploy to staging.
 * Search for a few queries that previously broke and confirm they now succeed:
   * `"red line`
   * `(red line`
   * `red line AND`
   * `red line OR`
   * `red line"`

Handles #732
