### PR TITLE
Update handling for event delete button

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -41,6 +41,20 @@ class SourcesMixin(object):
     def api_source(self):
         return self.sources.get(note='api')
 
+    @property
+    def api_representation(self):
+        response = requests.get(self.api_source.url)
+
+        if response.status_code != 200:
+            msg = 'Request to {0} resulted in non-200 status code: {1}'.format(
+                self.api_source.url, response.status_code
+            )
+            logger.warning(msg)
+            return None
+
+        else:
+            return response.json()
+
 
 class LAMetroBillManager(models.Manager):
     def get_queryset(self):
@@ -712,6 +726,17 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
         else:
             return 'Upcoming'
 
+    @property
+    def api_body_name(self):
+        '''
+        Return the name of the meeting body, as it would have appeared in the
+        API when scraped, for comparison to the current API data. This method
+        effectively undoes transformations applied in the events scraper:
+        https://github.com/opencivicdata/scrapers-us-municipal/blob/11a1532e46953eb2feec89ed6b978de0052b9fb7/lametro/events.py#L200-L211
+        '''
+        if self.name == 'Regular Board Meeting':
+            return 'Board of Directors - Regular Board Meeting'
+        return self.name
 
 class EventAgendaItem(EventAgendaItem):
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -160,17 +160,16 @@ class LAMetroEventDetail(EventDetailView):
         if self.request.user.is_authenticated:
             r = requests.get('https://metro.legistar.com/calendar.aspx')
             context['legistar_ok'] = r.ok
+
             # GET the event URL; allow admin to delete event if 404
             # or if event name has changed
             # https://github.com/datamade/la-metro-councilmatic/issues/692#issuecomment-934648716
-            response = requests.get(event.api_source.url)
+            api_rep = event.api_representation
 
-            if response.status_code != 200:
-                context['event_ok'] = False
+            if api_rep:
+                context['event_ok'] = event.api_body_name == api_rep['EventBodyName']
             else:
-                parsed_response = response.json()
-                name_changed = event.name != parsed_response['EventBodyName']
-                context['event_ok'] = not name_changed
+                context['event_ok'] = False
 
         try:
             context['minutes'] = event.documents.get(note__icontains='minutes')


### PR DESCRIPTION
## Overview

This PR lightly reorganizes existing code to check whether an event matches its API representation and handles the Regular Board Meeting condition.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Confirm CI passes.
 * Merge to deploy to staging, then confirm the delete button is not showing for every regular board meeting.

Handles #697 
