### PR TITLE
Minutes recap links

### DIFF
--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -219,7 +219,7 @@
                         <div class="col-xs-4">
 
                         {% if event.start_time|compare_time %}
-                        <h4>Minutes</h4>
+                            <h4>Minutes</h4>
                             {% if minutes %}
                             <p>
                                 <a href="{{ minutes.links.get.url }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -219,12 +219,11 @@
                         <div class="col-xs-4">
 
                         {% if event.start_time|compare_time %}
+                        <h4>Minutes</h4>
                             {% if minutes %}
-                            <h4>Minutes</h4>
                             <p>
                                 <a href="{{ minutes.links.get.url }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>
                             </p>
-                            {% endif %}
                             {% elif 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
                             <p>
                                 <a href="http://boardarchives.metro.net/recaps/" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> View Recap</a>

--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -219,20 +219,18 @@
                         <div class="col-xs-4">
 
                         {% if event.start_time|compare_time %}
-                            {% if 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
+                            {% if minutes %}
                             <h4>Minutes</h4>
+                            <p>
+                                <a href="{{ minutes.links.get.url }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>
+                            </p>
+                            {% endif %}
+                            {% elif 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
                             <p>
                                 <a href="http://boardarchives.metro.net/recaps/" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> View Recap</a>
                                 </br>
                             </p>
                             {% endif %}
-
-                                {% if minutes %}
-                                <p>
-                                    <a href="{{ minutes.links.get.url }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>
-                                </p>
-                                {% endif %}
-
                         {% endif %}
 
                         </div>

--- a/lametro/templates/partials/past_event_day.html
+++ b/lametro/templates/partials/past_event_day.html
@@ -55,14 +55,6 @@
 
     {% if event.start_time|compare_time %}
     <div class="col-xs-1">
-        {% if 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
-        <p>
-            <a href="http://boardarchives.metro.net/recaps/" target="_blank">Recap</a>
-            </br>
-        </p>
-        {% endif %}
-    </div>
-    <div class="col-xs-1">
         {% with minutes=event.minutes.0.links.all.0.url %}
             {% if minutes %}
             <p>
@@ -70,6 +62,12 @@
             </p>
             {% endif %}
         {% endwith %}
+        {% elif 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
+        <p>
+            <a href="http://boardarchives.metro.net/recaps/" target="_blank">Recap</a>
+            </br>
+        </p>
+        {% endif %}
     </div>
     {% endif %}
 

--- a/lametro/templates/partials/past_event_day.html
+++ b/lametro/templates/partials/past_event_day.html
@@ -60,14 +60,13 @@
             <p>
                 <a href="{{ minutes }}">Minutes</a>
             </p>
+            {% elif 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
+            <p>
+                <a href="http://boardarchives.metro.net/recaps/" target="_blank">Recap</a>
+                </br>
+            </p>
             {% endif %}
         {% endwith %}
-        {% elif 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
-        <p>
-            <a href="http://boardarchives.metro.net/recaps/" target="_blank">Recap</a>
-            </br>
-        </p>
-        {% endif %}
     </div>
     {% endif %}
 


### PR DESCRIPTION
## Overview

This PR updates the logic for showing minutes and recap links to favor minutes if available, and fall back on recaps.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * View the 4/22/2021 Board Meeting on the staging site and verify that only the minutes link is present in both the past meetings list and the event detail
 * 4/22/2021 meeting: https://lametro-upgrade.datamade.us/event/regular-board-meeting-ff063c93ee77/

Handles #753 
