### PR TITLE
Patch - Event shows minutes title only if minutes or recap

### DIFF
--- a/lametro/templates/lametro/event.html
+++ b/lametro/templates/lametro/event.html
@@ -219,12 +219,13 @@
                         <div class="col-xs-4">
 
                         {% if event.start_time|compare_time %}
-                            <h4>Minutes</h4>
                             {% if minutes %}
+                            <h4>Minutes</h4>
                             <p>
                                 <a href="{{ minutes.links.get.url }}"><i class="fa fa-calendar" aria-hidden="true"></i> View Minutes</a>
                             </p>
                             {% elif 'board meeting' in event.name|lower or 'la safe' in event.name|lower %}
+                            <h4>Minutes</h4>
                             <p>
                                 <a href="http://boardarchives.metro.net/recaps/" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> View Recap</a>
                                 </br>


### PR DESCRIPTION
## Overview

See title

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Visit an event detail page that doesn't have minutes or a recap link and make sure the "Minutes" title doesn't appear
 * Make sure that an event with a recap or minutes does have a "Minutes" link

Handles #753 
