### PR TITLE
Hidden bills display 404 instead of 500

### DIFF
--- a/configs/test_settings_deployment.py
+++ b/configs/test_settings_deployment.py
@@ -74,7 +74,7 @@ ANALYTICS_TRACKING_CODE = ''
 HEADSHOT_PATH = os.path.join(os.path.dirname(__file__), '..'
                              '/lametro/static/images/')
 
-SHOW_TEST_EVENTS = True
+SHOW_TEST_EVENTS = False
 
 SMART_LOGIC_KEY = 'smartlogic api key'
 SMART_LOGIC_ENVIRONMENT = '0ef5d755-1f43-4a7e-8b06-7591bed8d453'

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -145,11 +145,9 @@ class LAMetroEventDetail(EventDetailView):
         else:
             return self.render_to_response(self.get_context_data(url_form=url_form, pdf_form=pdf_form))
 
-    def get_object(self):
-        # Get the event with prefetched media_urls in proper order.
-        event = LAMetroEvent.objects.with_media().get(slug=self.kwargs['slug'])
-
-        return event
+    def get_queryset(self):
+        # Get the queryset with prefetched media_urls in proper order.
+        return LAMetroEvent.objects.with_media()
 
     def get_context_data(self, **kwargs):
         context = super(EventDetailView, self).get_context_data(**kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from opencivicdata.legislative.models import (
     EventRelatedEntity,
     )
 from opencivicdata.core.models import Jurisdiction, Division
-from opencivicdata.legislative.models import EventDocument, BillAction
+from opencivicdata.legislative.models import EventDocument, BillAction, EventLocation
 from councilmatic_core.models import Bill, Membership
 from lametro.models import LAMetroPerson, LAMetroEvent, LAMetroBill, \
     LAMetroOrganization, LAMetroSubject
@@ -339,3 +339,23 @@ def concurrent_current_meetings(event):
     construction_meeting = event.build(**construction_meeting_info)
 
     return board_meeting, construction_meeting
+
+@pytest.fixture
+@pytest.mark.django_db
+def event_location(db, jurisdiction):
+    class EventLocationFactory():
+        def build(self, **kwargs):
+            related_jurisdiction = jurisdiction
+
+            event_location_info = {
+                'name': 'TEST',
+                'jurisdiction': related_jurisdiction,
+            }
+
+            event_location_info.update(**kwargs)
+
+            event_location = EventLocation.objects.create(**event_location_info)
+
+            return event_location
+
+    return EventLocationFactory()

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -21,7 +21,7 @@ def test_bill_url(client, bill):
     This test checks that the bill detail view returns a successful response.
     '''
     bill = bill.build()
-    url = reverse('bill_detail', kwargs={'slug': bill.slug})
+    url = reverse('lametro:bill_detail', kwargs={'slug': bill.slug})
     response = client.get(url)
 
     assert response.status_code == 200

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -15,6 +15,7 @@ from lametro.models import LAMetroBill
 from lametro.utils import format_full_text, parse_subject
 
 # This collection of tests checks the functionality of Bill-specific views, helper functions, and relations.
+@pytest.mark.django_db
 def test_bill_url(client, bill):
     '''
     This test checks that the bill detail view returns a successful response.
@@ -251,15 +252,13 @@ def test_related_bill_respects_privacy(bill):
     assert private_related_bill.slug not in related_bills
 
 
-@pytest.mark.django_db
 def test_private_bill(client, bill):
     # test private bill (test with bill.extras.restrict_view; get 404)
     private_bill = bill.build(
         id='ocd-bill/{}'.format(str(uuid4())),
         extras={'restrict_view': True}
     )
-
-    url = reverse('bill_detail', kwargs={'slug': private_bill.slug})
+    url = reverse('lametro:bill_detail', kwargs={'slug': private_bill.slug})
     response = client.get(url)
     assert response.status_code == 404
 

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -254,7 +254,6 @@ def test_related_bill_respects_privacy(bill):
 
 
 def test_private_bill(client, bill):
-    # test private bill (test with bill.extras.restrict_view; get 404)
     private_bill = bill.build(
         id='ocd-bill/{}'.format(str(uuid4())),
         extras={'restrict_view': True}

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -14,7 +14,6 @@ from councilmatic_core.models import Bill, Event
 from lametro.models import LAMetroBill
 from lametro.utils import format_full_text, parse_subject
 
-
 # This collection of tests checks the functionality of Bill-specific views, helper functions, and relations.
 def test_bill_url(client, bill):
     '''
@@ -250,3 +249,17 @@ def test_related_bill_respects_privacy(bill):
 
     assert public_related_bill.slug in related_bills
     assert private_related_bill.slug not in related_bills
+
+
+@pytest.mark.django_db
+def test_private_bill(client, bill):
+    # test private bill (test with bill.extras.restrict_view; get 404)
+    private_bill = bill.build(
+        id='ocd-bill/{}'.format(str(uuid4())),
+        extras={'restrict_view': True}
+    )
+
+    url = reverse('bill_detail', kwargs={'slug': private_bill.slug})
+    response = client.get(url)
+    assert response.status_code == 404
+

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -15,7 +15,6 @@ from lametro.models import LAMetroBill
 from lametro.utils import format_full_text, parse_subject
 
 # This collection of tests checks the functionality of Bill-specific views, helper functions, and relations.
-@pytest.mark.django_db
 def test_bill_url(client, bill):
     '''
     This test checks that the bill detail view returns a successful response.

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -20,6 +20,8 @@ def test_bill_url(client, bill):
     This test checks that the bill detail view returns a successful response.
     '''
     bill = bill.build()
+    bill.classification = ['Board Box']
+    bill.save()
     url = reverse('lametro:bill_detail', kwargs={'slug': bill.slug})
     response = client.get(url)
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -13,7 +13,7 @@ import requests
 import requests_mock
 from unittest.mock import patch
 
-from opencivicdata.legislative.models import EventDocument
+from opencivicdata.legislative.models import EventDocument, EventLocation
 from councilmatic_core.models import Bill
 
 from lametro.models import LAMetroEvent, app_timezone
@@ -415,3 +415,18 @@ def test_delete_event(event, client, admin_client):
 
     event_in_db = LAMetroEvent.objects.filter(id=e.id)
     assert not event_in_db.exists()
+
+
+# test event (event location name = TEST; get 404)
+def test_private_event(client, event, mocker):
+    private_event = event.build()
+
+    mock_location = mocker.MagicMock(spec=EventLocation)
+    mock_location.name = 'TEST'
+
+    mocker.patch('lametro.models.LAMetroEvent.location', return_value=mock_location)
+
+    url = reverse('lametro:events', args=[private_event.slug])
+    response = client.get(url)
+
+    assert response.status_code == 404

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -418,12 +418,10 @@ def test_delete_event(event, client, admin_client):
 
 
 def test_private_event(client, event, event_location):
-    settings.SHOW_TEST_EVENTS = False
-
     location = event_location.build()
     private_event = event.build()
     private_event.location = location
-
+    private_event.save()
 
     url = reverse('lametro:events', args=[private_event.slug])
     response = client.get(url)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -417,14 +417,13 @@ def test_delete_event(event, client, admin_client):
     assert not event_in_db.exists()
 
 
-# test event (event location name = TEST; get 404)
-def test_private_event(client, event, mocker):
+def test_private_event(client, event, event_location):
+    settings.SHOW_TEST_EVENTS = False
+
+    location = event_location.build()
     private_event = event.build()
+    private_event.location = location
 
-    mock_location = mocker.MagicMock(spec=EventLocation)
-    mock_location.name = 'TEST'
-
-    mocker.patch('lametro.models.LAMetroEvent.location', return_value=mock_location)
 
     url = reverse('lametro:events', args=[private_event.slug])
     response = client.get(url)


### PR DESCRIPTION
## Overview
This PR defaults to the DetailView `get_object` method, which uses a 404 if an object does not exist, and overwrites the `get_queryset` method to include media links in the queryset.

[WIP] It also will implement tests for the event and bill models to make sure private bills and events display 404 pages.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Make sure CI passes

Handles #399 
