### PR TITLE
add 'Contact Us' page

### DIFF
--- a/councilmatic/urls.py
+++ b/councilmatic/urls.py
@@ -15,7 +15,8 @@ from lametro.api import SmartLogicAPI, PublicComment, refresh_guid_trigger, \
 from lametro.views import LAMetroIndexView, LAMetroEventDetail, LABillDetail, LABoardMembersView, \
     LAMetroAboutView, LACommitteeDetailView, LACommitteesView, LAPersonDetailView, \
     LAMetroEventsView, LAMetroCouncilmaticFacetedSearchView, GoogleView, \
-    metro_login, metro_logout, delete_submission, delete_event, LAMetroArchiveSearch
+    metro_login, metro_logout, delete_submission, delete_event, LAMetroArchiveSearch,\
+    LAMetroContactView
 from lametro.feeds import *
 
 patterns = ([
@@ -37,6 +38,7 @@ patterns = ([
     url(r'^person/(?P<slug>[^/]+)/rss/$', LAMetroPersonDetailFeed(), name='person_feed'),
     url(r'^google66b34bb6957ad66c.html/$', GoogleView.as_view(), name='google_view'),
     url(r'^public-comment/$', PublicComment.as_view(), name='public_comment'),
+    url(r'^contact/$', LAMetroContactView.as_view(), name='contact'),
 ], settings.APP_NAME)
 
 urlpatterns = [

--- a/lametro/templates/base.html
+++ b/lametro/templates/base.html
@@ -66,6 +66,9 @@
                     <li>
                         <a href="{% url 'lametro:archive-search' %}">Archive Search</a>
                     </li>
+                    <li>
+                        <a href="{% url 'lametro:contact' %}">Contact Us</a>
+                    </li>
                     {% nocache %}
                     <li>
                         {% if user.is_authenticated %}

--- a/lametro/templates/lametro/about.html
+++ b/lametro/templates/lametro/about.html
@@ -196,7 +196,13 @@
 
         <h3>Contact us</h3>
 
-        <p>Have a question about information you were seeking to find, or explanations of how Metro works? Send us an email <a href="mailto:boardreport@metro.net">boardreport@metro.net</a>.</p>
+        <div class="col-sm-12 no-pad-mobile">
+            <p>For questions about or comments for the Metro Board, please contact <a href="mailto:boardclerk@metro.net">boardclerk@metro.net</a>. Written public comment can be mailed to: Board Administration, 1 Gateway Plaza, Mail Stop 99-3-1, Los Angeles, CA 90012.</p>
+            <p>If you are commenting on a specific item, please include the item number and your position on it - for, against, general comment, or item needs more consideration - in your message. Written public comment (via mail or email) must be received by 5pm the evening prior to the meeting where the item will be considered.
+            </p>
+            <p>To provide live public comment during a meeting, please see page 4 of the agenda where item appears for instructions on how to call into the meeting.</p>
+            <p>For questions about this website or Board records, please email <a href="mailto:boardreport@metro.net">boardreport@metro.net</a>.</p>
+        </div>
 
     </div>
 </div>

--- a/lametro/templates/lametro/about.html
+++ b/lametro/templates/lametro/about.html
@@ -196,8 +196,12 @@
 
         <h3>Contact us</h3>
 
-        <div class="col-sm-12 no-pad-mobile">
-            <p>For questions about or comments for the Metro Board, please contact <a href="mailto:boardclerk@metro.net">boardclerk@metro.net</a>. Written public comment can be mailed to: Board Administration, 1 Gateway Plaza, Mail Stop 99-3-1, Los Angeles, CA 90012.</p>
+        <div>
+            <p>For questions about or comments for the Metro Board, please contact <a href="mailto:boardclerk@metro.net">boardclerk@metro.net</a>. Written public comment can be mailed to:
+            <br/><br/>
+            Board Administration<br/>
+            1 Gateway Plaza, Mail Stop 99-3-1<br/>
+            Los Angeles, CA 90012</p>
             <p>If you are commenting on a specific item, please include the item number and your position on it - for, against, general comment, or item needs more consideration - in your message. Written public comment (via mail or email) must be received by 5pm the evening prior to the meeting where the item will be considered.
             </p>
             <p>To provide live public comment during a meeting, please see page 4 of the agenda where item appears for instructions on how to call into the meeting.</p>

--- a/lametro/templates/lametro/contact.html
+++ b/lametro/templates/lametro/contact.html
@@ -9,14 +9,12 @@
     <div class="col-sm-9 no-pad-mobile">
       <h1>Contact Us</h1>
     </div>
-    <div class="col-sm-3 no-pad-mobile">
-      <div class="well info-blurb">
-        <p>For questions about or comments for the Metro Board, please contact <a href="mailto:boardclerk@metro.net">boardclerk@metro.net</a>. Written public comment can be mailed to: Board Administration, 1 Gateway Plaza, Mail Stop 99-3-1, Los Angeles, CA 90012.</p>
-        <p>If you are commenting on a specific item, please include the item number and your position on it - for, against, general comment, or item needs more consideration - in your message. Written public comment (via mail or email) must be received by 5pm the evening prior to the meeting where the item will be considered.
-        </p>
-        <p>To provide live public comment during a meeting, please see page 4 of the agenda where item appears for instructions on how to call into the meeting.</p>
-        <p>For questions about this website or Board records, please email <a href="mailto:boardreport@metro.net">boardreport@metro.net</a>.</p>
-      </div>
+    <div class="col-sm-9 no-pad-mobile">
+      <p>For questions about or comments for the Metro Board, please contact <a href="mailto:boardclerk@metro.net">boardclerk@metro.net</a>. Written public comment can be mailed to: Board Administration, 1 Gateway Plaza, Mail Stop 99-3-1, Los Angeles, CA 90012.</p>
+      <p>If you are commenting on a specific item, please include the item number and your position on it - for, against, general comment, or item needs more consideration - in your message. Written public comment (via mail or email) must be received by 5pm the evening prior to the meeting where the item will be considered.
+      </p>
+      <p>To provide live public comment during a meeting, please see page 4 of the agenda where item appears for instructions on how to call into the meeting.</p>
+      <p>For questions about this website or Board records, please email <a href="mailto:boardreport@metro.net">boardreport@metro.net</a>.</p>
     </div>
   </div>
 </div>

--- a/lametro/templates/lametro/contact.html
+++ b/lametro/templates/lametro/contact.html
@@ -10,7 +10,11 @@
       <h1>Contact Us</h1>
     </div>
     <div class="col-sm-9 no-pad-mobile">
-      <p>For questions about or comments for the Metro Board, please contact <a href="mailto:boardclerk@metro.net">boardclerk@metro.net</a>. Written public comment can be mailed to: Board Administration, 1 Gateway Plaza, Mail Stop 99-3-1, Los Angeles, CA 90012.</p>
+      <p>For questions about or comments for the Metro Board, please contact <a href="mailto:boardclerk@metro.net">boardclerk@metro.net</a>. Written public comment can be mailed to:
+      <br/><br/>
+      Board Administration<br/>
+      1 Gateway Plaza, Mail Stop 99-3-1<br/>
+      Los Angeles, CA 90012</p>
       <p>If you are commenting on a specific item, please include the item number and your position on it - for, against, general comment, or item needs more consideration - in your message. Written public comment (via mail or email) must be received by 5pm the evening prior to the meeting where the item will be considered.
       </p>
       <p>To provide live public comment during a meeting, please see page 4 of the agenda where item appears for instructions on how to call into the meeting.</p>

--- a/lametro/templates/lametro/contact.html
+++ b/lametro/templates/lametro/contact.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}Contact Us{% endblock %}
+
+{% block full_content %}
+<div class="container-fluid">
+  <div class="col-sm-12">
+  <div class="row-fluid">
+    <br />
+    <div class="col-sm-9 no-pad-mobile">
+      <h1>Contact Us</h1>
+    </div>
+    <div class="col-sm-3 no-pad-mobile">
+      <div class="well info-blurb">
+        <p>For questions about or comments for the Metro Board, please contact <a href="mailto:boardclerk@metro.net">boardclerk@metro.net</a>. Written public comment can be mailed to: Board Administration, 1 Gateway Plaza, Mail Stop 99-3-1, Los Angeles, CA 90012.</p>
+        <p>If you are commenting on a specific item, please include the item number and your position on it - for, against, general comment, or item needs more consideration - in your message. Written public comment (via mail or email) must be received by 5pm the evening prior to the meeting where the item will be considered.
+        </p>
+        <p>To provide live public comment during a meeting, please see page 4 of the agenda where item appears for instructions on how to call into the meeting.</p>
+        <p>For questions about this website or Board records, please email <a href="mailto:boardreport@metro.net">boardreport@metro.net</a>.</p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  (function() {
+    var cx = '007602828488985387677:mhzmxh6ty20';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+{% endblock %}

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -731,6 +731,9 @@ class LAMetroArchiveSearch(TemplateView):
     template_name = 'lametro/archive_search.html'
 
 
+class LAMetroContactView(IndexView):
+    template_name = 'lametro/contact.html'
+
 def metro_login(request):
     logout(request)
     if request.method == 'POST':


### PR DESCRIPTION
## Overview

This PR adds a "Contact Us" page, (and also updates the "Contact Us" section of the "About" page with the same text?)

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Check the text of the "Contact Us" page and the "Contact Us" section of "About" against the following from the issue description:
> "For questions about or comments for the Metro Board, please contact boardclerk@metro.net. Written public comment can be mailed to: Board Administration, 1 Gateway Plaza, Mail Stop 99-3-1, Los Angeles, CA 90012.
If you are commenting on a specific item, please include the item number and your position on it - for, against, general comment, or item needs more consideration - in your message. Written public comment (via mail or email) must be received by 5pm the evening prior to the meeting where the item will be considered.
To provide live public comment during a meeting, please see page 4 of the agenda where item appears for instructions on how to call into the meeting.

Handles #773
