### PR TITLE
Publish image to GHCR from master, deploy branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test and deploy
 
 on:
   push:

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -1,0 +1,24 @@
+name: Publish Docker image to GitHub Container Registry
+
+on:
+  push:
+    branches:
+      - master
+      - deploy
+
+jobs:
+  publish:
+    name: Publish Docker image to GitHub Container Registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${GITHUB_REF##*/}

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -21,4 +21,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ghcr.io/${{ github.repository }}:${GITHUB_REF##*/}
+          tags: ghcr.io/${{ github.repository }}:$GITHUB_REF_NAME


### PR DESCRIPTION
## Overview

See title. This change is needed because Dockerhub no longer provides free auto builds, so we're migrating to GitHub Container Registry to achieve the same purpose.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

Once I confirm this works, I'll make a twin PR in `datamade/scrapers-us-municipal`, then update the dashboard to pull images from GHCR. 

## Testing Instructions

 * Confirm test and deployment CI work as normal.
 * Merge, and again confirm test and CI deployment work as normal. Also confirm a `master` tag is created in GHCR.

Related to #738.