### PR TITLE
Revise action publishing to GHCR

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - deploy
-      - hcg/ci-update
 
 jobs:
   publish:

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - deploy
+      - hcg/ci-update
 
 jobs:
   publish:
@@ -17,8 +18,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create tag from branch
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
       - name: Push to GitHub Packages
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ env.GITHUB_REF_NAME }}
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Overview

This PR revises #780. It uses [the `docker/metadata-action` plug-in](https://github.com/docker/metadata-action) to build `master` and `deploy` tags from the relevant branch.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Merge and confirm that test/deploy CI works as expected and a `master` tag is created in GHCR.
