### PR TITLE
Patch topic display on board report detail pages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=2.2,<2.3
+Django>=2.2,<2.2.26
 psycopg2-binary>=2.8,<2.9
 opencivicdata>=3.1.0
 django-councilmatic[convert_docs]==2.6.1


### PR DESCRIPTION
## Overview

The behavior of the `dictsort` template filter [changed in Django 2.2.26](https://docs.djangoproject.com/en/4.0/releases/2.2.26/#cve-2021-45116-potential-information-disclosure-in-dictsort-template-filter), preventing topics from rendering correctly. This PR pins Django to preserve its original behavior and restore topics.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Check out this branch
 * Build the app image to capture the change in dependencies: `docker-compose build app`
 * Run the app: `docker-compose up app`
 * View any board report and confirm you see topics listed.

Handles #789
