### PR TITLE
Added redistricting alert to Board of Directors Page

### DIFF
--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -125,3 +125,9 @@ HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
 HAYSTACK_IDENTIFIER_METHOD = 'lametro.utils.get_identifier'
 
 ADV_CACHE_INCLUDE_PK = True
+
+# Django Debug Toolbar Panel Settings
+DEBUG_TOOLBAR_PANELS = [
+    'debug_toolbar.panels.sql.SQLPanel',
+    'debug_toolbar.panels.cache.CachePanel',
+]

--- a/lametro/templates/lametro/board_members.html
+++ b/lametro/templates/lametro/board_members.html
@@ -27,7 +27,6 @@
 </div>
 
 <div class="container-fluid">
-
     {% if MAP_CONFIG %}
     <div class="row">
         <div class="col-sm-6">

--- a/lametro/templates/lametro/board_members.html
+++ b/lametro/templates/lametro/board_members.html
@@ -20,6 +20,14 @@
 {% cache 86400 members_wrapper 'members' %}
 
 <div class="container-fluid">
+    <br>
+    <div class="alert alert-danger mt-3" role="alert">
+        On December 15, 2021, the County of Los Angles Citizens Redistricting Commission passed resolutions to adopt a final redistricting <a href='https://redistricting.lacounty.gov/wp-content/uploads/2021/12/LA-County-CRC-Resolution-Adopting-Redistricting-Plan.pdf'>plan</a> and <a href='https://redistricting.lacounty.gov/wp-content/uploads/2021/12/LA-County-CRC-Resolution-Adopting-Redistricting-Report.pdf'>report</a>. Click <a href='https://redistricting-lacounty.hub.arcgis.com/'>here</a> to view the final redistricting plan and all other submitted maps in the Redistricting Hub. The map on this page will be updated once the County provides finalized maps.
+    </div>
+</div>
+
+<div class="container-fluid">
+
     {% if MAP_CONFIG %}
     <div class="row">
         <div class="col-sm-6">

--- a/lametro/templates/lametro/board_members.html
+++ b/lametro/templates/lametro/board_members.html
@@ -21,8 +21,14 @@
 
 <div class="container-fluid">
     <br>
-    <div class="alert alert-danger mt-3" role="alert">
-        On December 15, 2021, the County of Los Angles Citizens Redistricting Commission passed resolutions to adopt a final redistricting <a href='https://redistricting.lacounty.gov/wp-content/uploads/2021/12/LA-County-CRC-Resolution-Adopting-Redistricting-Plan.pdf'>plan</a> and <a href='https://redistricting.lacounty.gov/wp-content/uploads/2021/12/LA-County-CRC-Resolution-Adopting-Redistricting-Report.pdf'>report</a>. Click <a href='https://redistricting-lacounty.hub.arcgis.com/'>here</a> to view the final redistricting plan and all other submitted maps in the Redistricting Hub. The map on this page will be updated once the County provides finalized maps.
+    <div class="alert alert-info mt-3" role="alert">
+        On December 15, 2021, the County of Los Angles Citizens Redistricting Commission
+        passed resolutions to adopt a final redistricting 
+        <a href='https://redistricting.lacounty.gov/wp-content/uploads/2021/12/LA-County-CRC-Resolution-Adopting-Redistricting-Plan.pdf'>plan</a> 
+        and <a href='https://redistricting.lacounty.gov/wp-content/uploads/2021/12/LA-County-CRC-Resolution-Adopting-Redistricting-Report.pdf'>report</a>. 
+        Click <a href='https://redistricting-lacounty.hub.arcgis.com/'>here</a> to view 
+        the final redistricting plan and all other submitted maps in theRedistricting Hub. 
+        The map on this page will be updated once the County provides finalized maps.
     </div>
 </div>
 


### PR DESCRIPTION
## Overview

Adds an alert to the top of the Board of Directors page notifying users of changes due to redistricting.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs


### Demo

<img width="1213" alt="Screen Shot 2022-02-23 at 11 37 27 AM" src="https://user-images.githubusercontent.com/36973363/155364748-ce8c8812-f55a-4d3f-8d5a-ea40c96fcd27.png">


### Notes

`django-debug-toolbar` seemed to have been causing some performance issues during development so we also pared down its displayed panels to only SQL and Cache.


## Testing Instructions

 * Visit the Board of Directors page and verify that the alert is displayed, the links are valid, and the alert is responsive.

Handles #798 
