### PR TITLE
Open board reports search results in a new tab

### DIFF
--- a/lametro/templates/partials/search_result.html
+++ b/lametro/templates/partials/search_result.html
@@ -3,7 +3,7 @@
 {% load highlight %}
 
 <p>
-    <a class="small" href="{% url 'lametro:bill_detail' r.object.slug %}">
+    <a class="small" target='_blank' href="{% url 'lametro:bill_detail' r.object.slug %}">
         {{ r.object.friendly_name }}
     </a>
     {% if r.object.inferred_status %}{{ r.object.inferred_status | inferred_status_label | safe }}{% endif %}
@@ -28,7 +28,7 @@
     </div>
     <div class='col-xs-1 no-pad-mobile'>
         <div>
-            <a class='btn-bill-detail' href='/board-report/{{ r.object.slug }}/'>
+            <a class='btn-bill-detail' target='_blank' href='/board-report/{{ r.object.slug }}/'>
                 <i class="fa fa-fw fa-chevron-right"></i>
             </a>
         </div>


### PR DESCRIPTION
## Overview

Opens board reports search results in a new tab.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs


## Testing Instructions

 * Visit the Board Reports page and type in a search query.
 * Verify that search results open in a new tab.

Handles #788 
