### PR TITLE
Removed Title VI banner from homepage

### DIFF
--- a/lametro/templates/partials/banner.html
+++ b/lametro/templates/partials/banner.html
@@ -8,8 +8,4 @@
         <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
         * De acuerdo con AB361, las reuniones de la Junta Directiva y el Comité continuarán llevándose a cabo virtualmente mientras exista una declaración del estado de emergencia. <a class="alert-link" href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202120220AB361" target="_blank">Haga clic aquí &raquo;</a>
     </div>
-    <div class="alert alert-danger" role="alert">
-        <i class="fa fa-fw fa-exclamation-circle" aria-hidden="true"></i>
-        * Stream Crenshaw Light Rail Line and Regional Connector Transit Project Public Hearings; and February Title VI Public Hearings. <a class="alert-link" href="https://www.metro.net/about/board-directors-meetings-audio-archive" target="_blank">Click here &raquo;</a>
-    </div>
 </div>


### PR DESCRIPTION
## Overview

Removes Title VI banner from homepage.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="1440" alt="Screen Shot 2022-03-15 at 11 27 16 AM" src="https://user-images.githubusercontent.com/36973363/158412847-5f681655-1ef1-4029-834b-ae71ada7be36.png">


## Testing Instructions

 * Navigate to the homepage and verify that the banner has been removed.

Handles #807 
