### PR TITLE
Patch identifier search

### DIFF
--- a/lametro/views.py
+++ b/lametro/views.py
@@ -639,7 +639,11 @@ class IdentifierBoostSearchQuery(SolrSearchQuery):
         Reference:
         https://medium.com/@pablocastelnovo/if-they-match-i-want-them-to-be-always-first-boosting-documents-in-apache-solr-with-the-boost-362abd36476c
         '''
-        identifiers = set(re.findall('\d{4}-\d{4}', self.build_query()))
+        # Remove slashes escaping the dash in an identifier
+        identifiers = set(
+            i.replace('\\', '') for i in
+            re.findall(r'\d{4}\\-\d{4}', self.build_query())
+        )
 
         if identifiers:
             kwargs.update({


### PR DESCRIPTION
## Overview

This PR patches functionality to boost results exactly matching an identifier search term. This was broken by the logic we added to escape special characters in queries. 

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Run the app locally
 * Run an identifier search
 * In the app logs, you should see info records from pysolr that look like this:
```
lametro     | [11:45:34][INFO] pysolr pysolr.py:_send_request:402 | Finished 'http://solr:8983/solr/lametro/select/?q=%28%28%282022%5C%5C%5C-0044%29+AND+text%3A2022%5C-0044%29+OR+attachment_text%3A2022%5C-0044%29&fl=%2A+score&df=text&start=0&rows=20&hl=true&hl.fragsize=200&hl.fl=text%2Cattachment_text&facet=on&facet.field=bill_type_exact&facet.field=sponsorships_exact&facet.field=legislative_session_exact&facet.field=inferred_status_exact&facet.field=topics_exact&facet.field=lines_and_ways_exact&facet.field=phase_exact&facet.field=project_exact&facet.field=metro_location_exact&facet.field=geo_admin_location_exact&facet.field=motion_by_exact&facet.field=significant_date_exact&facet.field=plan_program_policy_exact&f.bill_type_exact.facet.sort=index&f.sponsorships_exact.facet.sort=index&f.legislative_session_exact.facet.sort=index&fq=django_ct%3A%28lametro.lametrobill%29&defType=edismax&bq=identifier%3A%222022-0044%22%5E2.0&wt=json' (get) with body '' in 0.453 seconds, with status 200
```
* Search for an identifier (like 2022-0044), and confirm you see something like `defType=edismax&bq=identifier%3A%222022-0044%22%5E2.0` at the end of the search URL.
* Run a search not containing an identifier and confirm you _don't_ see the defType & bq URL parameters in the search URL.

Handles #487
