### PR TITLE
Add tag analytics management command

### DIFF
--- a/lametro/management/commands/generate_tag_analytics.py
+++ b/lametro/management/commands/generate_tag_analytics.py
@@ -1,4 +1,5 @@
 import csv
+from tqdm import tqdm
 from django.core.management.base import BaseCommand
 
 from lametro.models import LAMetroBill
@@ -12,13 +13,19 @@ class Command(BaseCommand):
 
         with open('tag_analytics.csv', 'w', newline='') as f:
             writer = csv.writer(f, delimiter=',')
-            files = [(b.board_report.id,
-                      b.identifier,
-                      b.friendly_name,
-                      b.last_action_date,
-                      b.subject) for b in LAMetroBill.objects.all()]
+            files = []
+            for bill in LAMetroBill.all_objects.all():
+                if bill.board_report:
+                    files.append(
+                        (bill.board_report.id,
+                         bill.identifier,
+                         bill.friendly_name,
+                         bill.last_action_date,
+                         bill.subject)
+                    )
+
             writer.writerow(['File ID', 'Identifier', 'Title', 'Last Action Date', 'Tag'])
-            for report_id, identifier, title, last_action_date, tags in files:
+            for report_id, identifier, title, last_action_date, tags in tqdm(files):
                 for tag in tags:
                     writer.writerow([
                         str(report_id),

--- a/lametro/management/commands/generate_tag_analytics.py
+++ b/lametro/management/commands/generate_tag_analytics.py
@@ -1,0 +1,29 @@
+import csv
+from django.core.management.base import BaseCommand
+
+from lametro.models import LAMetroBill
+
+
+class Command(BaseCommand):
+
+    help = "This command produces a CSV file that lists each Board Report's tags."
+
+    def handle(self, *args, **options):
+
+        with open('tag_analytics.csv', 'w', newline='') as f:
+            writer = csv.writer(f, delimiter=',')
+            files = [(b.board_report.id,
+                      b.identifier,
+                      b.friendly_name,
+                      b.last_action_date,
+                      b.subject) for b in LAMetroBill.objects.all()]
+            writer.writerow(['File ID', 'Identifier', 'Title', 'Last Action Date', 'Tag'])
+            for report_id, identifier, title, last_action_date, tags in files:
+                for tag in tags:
+                    writer.writerow([
+                        str(report_id),
+                        identifier,
+                        title,
+                        last_action_date,
+                        tag,
+                    ])

--- a/lametro/management/commands/generate_tag_analytics.py
+++ b/lametro/management/commands/generate_tag_analytics.py
@@ -13,24 +13,25 @@ class Command(BaseCommand):
 
         with open('tag_analytics.csv', 'w', newline='') as f:
             writer = csv.writer(f, delimiter=',')
-            files = []
-            for bill in LAMetroBill.all_objects.all():
-                if bill.board_report:
-                    files.append(
+            writer.writerow(
+                ('File ID',
+                 'Identifier'
+                 'Title',
+                 'Last Action Date',
+                 'Tag Classification',
+                 'Tag')
+            )
+
+            for bill in tqdm(LAMetroBill.objects.all()):
+                if not bill.board_report:
+                    continue
+
+                for tag in bill.rich_topics:
+                    writer.writerow(
                         (bill.board_report.id,
                          bill.identifier,
                          bill.friendly_name,
                          bill.last_action_date,
-                         bill.subject)
+                         tag.classification,
+                         tag.name)
                     )
-
-            writer.writerow(['File ID', 'Identifier', 'Title', 'Last Action Date', 'Tag'])
-            for report_id, identifier, title, last_action_date, tags in tqdm(files):
-                for tag in tags:
-                    writer.writerow([
-                        str(report_id),
-                        identifier,
-                        title,
-                        last_action_date,
-                        tag,
-                    ])

--- a/lametro/management/commands/generate_tag_analytics.py
+++ b/lametro/management/commands/generate_tag_analytics.py
@@ -23,9 +23,6 @@ class Command(BaseCommand):
             )
 
             for bill in tqdm(LAMetroBill.objects.all()):
-                if not bill.board_report:
-                    continue
-
                 for tag in bill.rich_topics:
                     writer.writerow(
                         (bill.board_report.id,

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -120,7 +120,6 @@ class LAMetroBillManager(models.Manager):
 
 class LAMetroBill(Bill, SourcesMixin):
     objects = LAMetroBillManager()
-    all_objects = models.Manager()
 
     class Meta:
         proxy = True

--- a/lametro/models.py
+++ b/lametro/models.py
@@ -120,6 +120,7 @@ class LAMetroBillManager(models.Manager):
 
 class LAMetroBill(Bill, SourcesMixin):
     objects = LAMetroBillManager()
+    all_objects = models.Manager()
 
     class Meta:
         proxy = True


### PR DESCRIPTION
## Overview

Adds a django-admin command to produce a CSV file that links each board report to its tags. The CSV's fields are:

- File ID
- Identifier
- Title
- Last Action Date
- Tag Classification
- Tag

The file is saved to the root directory.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Run `docker-compose run --rm app python manage.py generate_tag_analytics`
 * Examine the generated CSV file

Handles #811 
