### PR TITLE
Order most recent past meetings by date in descending order

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -497,7 +497,7 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
         two_weeks_ago = timezone.now() - timedelta(weeks=2)
 
         meetings_in_past_two_weeks = cls.objects.filter(
-            start_time__month=current_month, start_time__gte=two_weeks_ago)
+            start_time__month=current_month, start_time__gte=two_weeks_ago).order_by('-start_time')
 
         # since has_passed is a property of LAMetroEvent rather than
         # a model attribute, we have to make sure returned meetings 


### PR DESCRIPTION
## Overview

Display most recent past meetings by date in descending order on homepage.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Navigate to homepage and verify that most recent past meetings are in descending order by date.
