### PR TITLE
Update Recent Meetings section

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -496,7 +496,7 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
         current_month = timezone.now().month
         two_weeks_ago = timezone.now() - timedelta(weeks=2)
 
-        meetings_in_past_two_weeks = cls.objects.filter(
+        meetings_in_past_two_weeks = cls.objects.with_media().filter(
             start_time__month=current_month, start_time__gte=two_weeks_ago).order_by('-start_time')
 
         # since has_passed is a property of LAMetroEvent rather than

--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -63,8 +63,13 @@ h1, .h1 {
     margin-bottom: 0px !important;
 }
 
+#upcoming-meetings {
+    margin-bottom: 20px;
+}
+
 #past-meetings {
-    padding-top: 20px;
+    border-top: 1px solid #ccc;
+    margin-top: 10px;
 }
 
 #map { margin-bottom: 2em; }

--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -58,6 +58,15 @@ h1, .h1 {
     padding-bottom: 20px;
 }
 
+#section-events h2 {
+    margin-top: 20px !important;
+    margin-bottom: 0px !important;
+}
+
+#past-meetings {
+    padding-top: 20px;
+}
+
 #map { margin-bottom: 2em; }
 
 #map-screenshot { width: 90%; }

--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -67,11 +67,6 @@ h1, .h1 {
     margin-bottom: 20px;
 }
 
-#past-meetings {
-    border-top: 1px solid #ccc;
-    margin-top: 10px;
-}
-
 #map { margin-bottom: 2em; }
 
 #map-screenshot { width: 90%; }

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -88,7 +88,12 @@
             </div>
         </div>
         <div class="row-fluid">
-            <div class="col-sm-10 col-sm-offset-1" id="past-meetings">
+            <div class="col-sm-12">
+                <hr>
+            </div>
+        </div>
+        <div class="row-fluid">
+            <div class="col-sm-10 col-sm-offset-1">
                 <h2>
                     <span class="non-mobile-only"><i class="fa fa-calendar-check-o" aria-hidden="true"></i>
 </span>

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -65,7 +65,7 @@
 
     <div class="container-fluid" id="section-events">
         <div class="row-fluid">
-            <div class='col-sm-10 col-sm-offset-1'>
+            <div class="col-sm-10 col-sm-offset-1" id="upcoming-meetings">
                 <h2>
                     <span class="non-mobile-only"><i class="fa fa-fw fa-group"></i> </span>
                     Upcoming Meetings
@@ -88,7 +88,7 @@
             </div>
         </div>
         <div class="row-fluid">
-            <div class='col-sm-10 col-sm-offset-1' id='past-meetings'>
+            <div class="col-sm-10 col-sm-offset-1" id="past-meetings">
                 <h2>
                     <span class="non-mobile-only"><i class="fa fa-calendar-check-o" aria-hidden="true"></i>
 </span>

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -88,7 +88,7 @@
             </div>
         </div>
         <div class="row-fluid">
-            <div class='col-sm-10 col-sm-offset-1'>
+            <div class='col-sm-10 col-sm-offset-1' id='past-meetings'>
                 <h2>
                     <span class="non-mobile-only"><i class="fa fa-calendar-check-o" aria-hidden="true"></i>
 </span>
@@ -96,7 +96,7 @@
                 </h2>
                 {% if most_recent_past_meetings %}
                     {% for event in most_recent_past_meetings %}
-                        {% include "partials/event_item.html" %}
+                        {% include "partials/past_event_item.html" %}
                     {% endfor %}
                 {% else %}
                     <br>

--- a/lametro/templates/partials/past_event_item.html
+++ b/lametro/templates/partials/past_event_item.html
@@ -32,10 +32,12 @@
         {% if event.media %}
           {% for media in event.media.all %}
             <p>
-              <a class="btn btn-sm btn-primary" href="{{ media.links.all.0.url }}" target="_blank">{% if media.note == 'Audio (SAP)' %}Ver en Español{% else %}Watch in English{% endif %}</a>
-              </br>
-            </p>
+            <a class="btn btn-sm btn-primary" href="{{ media.links.all.0.url }}" target="_blank">
+              <i class="fa fa-headphones" aria-hidden="true"></i>
+              {% if media.note == 'Audio (SAP)' %}Ver en Español{% else %}Watch in English{% endif %}
+            </a>
           {% endfor %}
+          </br>
         {% endif %}
 
       {% endif %}

--- a/lametro/templates/partials/past_event_item.html
+++ b/lametro/templates/partials/past_event_item.html
@@ -1,0 +1,44 @@
+<div class="row">
+  <br/>
+  <div class="col-xs-4">
+    {% if event.status == 'cancelled' %}
+      <strike>
+    {% endif %}
+      <small>
+        <i class="fa fa-fw fa-calendar-o"></i>
+        <span class="non-mobile-only">
+          {{event.start_time | date:"D"}}
+        </span>
+        {{event.start_time | date:"m/d"}}
+        <span class="non-mobile-only">
+          <i class="fa fa-fw fa-clock-o"></i>
+        </span>
+        {{event.start_time| date:"g:ia"}}<br/>
+      </small>
+    {% if event.status == 'cancelled' %}
+      </strike>
+    {% endif %}
+  </div>
+
+  <div class="col-xs-8">
+    <p>
+      {% if event.status == 'cancelled' %}
+        <strike>{{ event.link_html | safe }}</strike>
+        <span class="label label-stale">Cancelled</span>
+        <br/>
+      {% else %}
+        {{ event.link_html | safe }}<br/>
+
+        {% if event.media %}
+          {% for media in event.media.all %}
+            <p>
+              <a class="btn btn-sm btn-primary" href="{{ media.links.all.0.url }}" target="_blank">{% if media.note == 'Audio (SAP)' %}Ver en Español{% else %}Watch in English{% endif %}</a>
+              </br>
+            </p>
+          {% endfor %}
+        {% endif %}
+
+      {% endif %}
+    </p>
+  </div>
+</div>

--- a/lametro/templates/partials/past_event_item.html
+++ b/lametro/templates/partials/past_event_item.html
@@ -7,13 +7,13 @@
       <small>
         <i class="fa fa-fw fa-calendar-o"></i>
         <span class="non-mobile-only">
-          {{event.start_time | date:"D"}}
+          {{ event.start_time | date:"D" }}
         </span>
-        {{event.start_time | date:"m/d"}}
+        {{ event.start_time | date:"m/d" }}
         <span class="non-mobile-only">
           <i class="fa fa-fw fa-clock-o"></i>
         </span>
-        {{event.start_time| date:"g:ia"}}<br/>
+        {{ event.start_time| date:"g:ia" }}<br/>
       </small>
     {% if event.status == 'cancelled' %}
       </strike>


### PR DESCRIPTION
## Overview

Implemented [requested changes](https://github.com/datamade/la-metro-councilmatic/issues/790#issuecomment-1071616180) to Recent Meetings section on homepage.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

![new recent meetings](https://user-images.githubusercontent.com/36973363/159078847-abff2649-050d-4cfc-ba11-a948f7bd8a21.png)


## Testing Instructions

 * Navigate to the homepage and examine the changes
 * Verify that in the Recent Meetings section, entries do not have location info and do have links to watch the meeting in English (and if available, Spanish)
 * Verify that there is increased spacing between the Upcoming Meetings and Recent Meetings sections
 * Verify that there is decreased spacing between the Recent Meetings title element and the event that proceeds it
 
Handles #805 
