### PR TITLE
Fix cancelled meetings label on Homepage

### DIFF
--- a/lametro/models.py
+++ b/lametro/models.py
@@ -744,12 +744,12 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
 
     @property
     def display_status(self):
-        if self.has_passed:
+        if self.status == 'cancelled':
+            return 'Cancelled'
+        elif self.has_passed:
             return 'Concluded'
         elif self.is_ongoing:
             return 'In progress'
-        elif self.status == 'cancelled':
-            return 'Cancelled'
         else:
             return 'Upcoming'
 

--- a/lametro/templates/partials/todays_meetings.html
+++ b/lametro/templates/partials/todays_meetings.html
@@ -1,27 +1,52 @@
 <h3>Today's Meetings</h3>
     {% for meeting in todays_meetings %}
-    {% if meeting.display_status == 'cancelled' %}
-        <strike>{{  meeting.link_html | safe }}</strike> <small><span class="label label-stale">Cancelled</span></small>
-    {% else %}
-        {{  meeting.link_html | safe }} <small>
-            {% if meeting.display_status == 'Concluded' %}<span class="label label-stale">
-            {% elif meeting.display_status == 'In progress' %}<span class="label label-primary">
-            {% elif meeting.display_status == 'Upcoming' %}<span class="label label-info">
-            {% endif %}
-            {{ meeting.display_status }}</span></small>
-    {% endif %}
-    <p class="small text-muted">
-    {% if meeting.status == 'cancelled' %}
-        <strike>
-          <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y" }}<br/>
-          <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a" }}<br/>
-        </strike>
-        {% else %}
-        <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y" }}<br/>
-        <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a" }}<br/>
-        {% if meeting.display_status == 'Upcoming' or meeting.display_status == 'In progress' %}
-        <i class="fa fa-fw fa-map-marker"></i> {{ meeting.location.name }}<br />
+        {% if meeting.status == 'cancelled' %}
+            <strike> {{  meeting.link_html | safe }} </strike>
+            <small>
+                <span class="label label-stale">
+                    Cancelled
+                </span>
+            </small>
+            <p class="small text-muted">
+                <strike>
+                  <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y" }}<br/>
+                  <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a" }}<br/>
+                </strike>
+            </p>
+        {% elif meeting.display_status == 'Concluded' %}
+            {{  meeting.link_html | safe }} 
+            <small>
+                <span class="label label-stale">
+                    {{ meeting.display_status }}
+                </span>
+            </small>
+            <p class="small text-muted">
+                <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y" }}<br/>
+                <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a" }}<br/>
+            </p>
+        {% elif meeting.display_status == 'In progress' %}
+            {{  meeting.link_html | safe }} 
+            <small>
+                <span class="label label-primary">
+                    {{ meeting.display_status }}
+                </span>
+            </small>
+            <p class="small text-muted">
+                <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y" }}<br/>
+                <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a" }}<br/>
+                <i class="fa fa-fw fa-map-marker"></i> {{ meeting.location.name }}<br />
+            </p>
+        {% elif meeting.display_status == 'Upcoming' %}
+            {{  meeting.link_html | safe }} 
+            <small>
+                <span class="label label-info">
+                    {{ meeting.display_status }}
+                </span>
+            </small>
+            <p class="small text-muted">
+                <i class="fa fa-fw fa-calendar-o"></i> {{ meeting.start_time | date:"D n/d/Y" }}<br/>
+                <i class="fa fa-fw fa-clock-o"></i> {{ meeting.start_time | date:"g:i a" }}<br/>
+                <i class="fa fa-fw fa-map-marker"></i> {{ meeting.location.name }}<br />
+            </p>
         {% endif %}
-    {% endif %}
-    </p>
     {% endfor %}

--- a/lametro/templates/partials/todays_meetings.html
+++ b/lametro/templates/partials/todays_meetings.html
@@ -1,6 +1,6 @@
 <h3>Today's Meetings</h3>
     {% for meeting in todays_meetings %}
-        {% if meeting.status == 'cancelled' %}
+        {% if meeting.display_status == 'Cancelled' %}
             <strike> {{  meeting.link_html | safe }} </strike>
             <small>
                 <span class="label label-stale">

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -472,7 +472,6 @@ def test_display_status(event):
     assert cancelled_this_morning.display_status == 'Cancelled'
 
 
-
 def test_todays_meetings(event):
     # create event for some day
     event_time = app_timezone.localize(datetime(2020, 3, 15, 15, 0, 0, 0)) # March 15, 2020 at 3pm LA time

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -458,15 +458,12 @@ def test_most_recent_past_meetings(event):
 def test_display_status(event):
     this_morning = LAMetroEvent._time_ago(minutes=120).strftime('%Y-%m-%d %H:%M')
 
-    e = event.build(
+    cancelled_this_morning = event.build(
         name='Board Meeting',
         start_date=this_morning,
         status='cancelled',
         id=get_event_id()
     )
-
-    # Get event from queryset so it has the start_time annotation from the manager
-    cancelled_this_morning = LAMetroEvent.objects.get(id=e.id)
 
     assert cancelled_this_morning.has_passed == True
     assert cancelled_this_morning.display_status == 'Cancelled'

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -454,6 +454,25 @@ def test_most_recent_past_meetings(event):
     assert event_earlier_today in recent_past_meetings
 
 
+@freeze_time("2021-02-07 12:00:00")
+def test_display_status(event):
+    this_morning = LAMetroEvent._time_ago(minutes=120).strftime('%Y-%m-%d %H:%M')
+
+    e = event.build(
+        name='Board Meeting',
+        start_date=this_morning,
+        status='cancelled',
+        id=get_event_id()
+    )
+
+    # Get event from queryset so it has the start_time annotation from the manager
+    cancelled_this_morning = LAMetroEvent.objects.get(id=e.id)
+
+    assert cancelled_this_morning.has_passed == True
+    assert cancelled_this_morning.display_status == 'Cancelled'
+
+
+
 def test_todays_meetings(event):
     # create event for some day
     event_time = app_timezone.localize(datetime(2020, 3, 15, 15, 0, 0, 0)) # March 15, 2020 at 3pm LA time


### PR DESCRIPTION
## Overview

In the "Today's Meetings" portion of the homepage, cancelled meetings earlier in the day were incorrectly displayed as "Concluded". This seems to be because the `LAMetroEvent.display_status()` checked whether or not an event has passed before checking if it had been cancelled.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

I did some refactoring in `todays_meetings.html`. While going through the code, I found it to be a little difficult to parse due to the many nested tags and conditionals. More code is repeated but I thought that what's gained in clarity was worth the increase in length.

But if we'd rather leave it in its previous format, I'm more than happy to change it back.

## Testing Instructions

 * Run the tests
 * Verify that cancelled meetings are labeled as 'Cancelled' rather than 'Concluded' on the homepage

Handles #818 
