### PR TITLE
Don't create duplicate meeting broadcast records

### DIFF
--- a/lametro/management/commands/check_current_meeting.py
+++ b/lametro/management/commands/check_current_meeting.py
@@ -18,9 +18,12 @@ class Command(BaseCommand):
         if streaming_meeting.exists():
             streaming_meeting = streaming_meeting.get()
 
-            EventBroadcast.objects.create(event=streaming_meeting)
+            _, created = EventBroadcast.objects.get_or_create(
+                event=streaming_meeting
+            )
 
-            logger.info('Meeting marked as has broadcast: {}'.format(streaming_meeting))
+            if created:
+                logger.info('Meeting marked as has broadcast: {}'.format(streaming_meeting))
 
         else:
             logger.info('No streaming meetings found')

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -239,6 +239,12 @@ def test_streamed_meeting_is_marked_as_broadcast(concurrent_current_meetings, mo
     assert test_event_b.is_upcoming
     assert not any([test_event_b.is_ongoing, test_event_b.has_passed])
 
+    # Test that duplicate broadcast records are not created
+    call_command('check_current_meeting')
+
+    test_event_a.refresh_from_db()
+    assert test_event_a.broadcast.count() == 1
+
     # Fast forward an hour, no longer return Event A from the running events
     # endpoint, and assert that it has the correct status. Also assert Event B
     # is still upcoming, since it has not yet broadcast.


### PR DESCRIPTION
## Overview

This PR updates `check_current_meeting` so duplicate records of meeting broadcasts are not created.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Confirm CI passes.

Handles #838