### PR TITLE
Add label to board report type

### DIFF
--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -171,6 +171,10 @@ strong.match-group {
     display: inline-block;
 }
 
+.label-info {
+  background-color: #EB6864;
+}
+
 .label-teal { background-color: #49A6AB; }
 
 .label-received, .label-approved, .label-adopted {

--- a/lametro/templates/lametro/legislation.html
+++ b/lametro/templates/lametro/legislation.html
@@ -19,7 +19,9 @@
                     <br>
                 </h1>
                 <h1>
-                    {{ legislation.bill_type }}
+				  <span class="label label-info">
+					{{ legislation.bill_type }}
+				  </span>
 
                     {% if legislation.inferred_status %}
                         {{ legislation.inferred_status | inferred_status_label | safe }}


### PR DESCRIPTION
## Overview

This PR adds a label to the board report type on report pages.

### Demo

<img width="1337" alt="Screen Shot 2022-05-10 at 9 44 15 AM" src="https://user-images.githubusercontent.com/36973363/167643256-83064b42-a524-416d-a3c1-637267ba09b3.png">


## Testing Instructions

 * Navigate to a board report page and verify that the report type has a label to distinguish it from the report title

Handles #842 
