### PR TITLE
Changed text when no recent meetings

### DIFF
--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -105,7 +105,7 @@
                     {% endfor %}
                 {% else %}
                     <br>
-                    <p><em>No meetings in the past two weeks of this month.</em></p>
+                    <p><em>No meetings in the past two weeks.</em></p>
                 {% endif %}
                 <br/>
                 <a href="/events/" class="btn btn-sm btn-primary">


### PR DESCRIPTION
## Overview

Updates text displayed in the Recent Meetings section when there have been no meetings in the past two weeks.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="330" alt="Screen Shot 2022-05-18 at 9 51 43 AM" src="https://user-images.githubusercontent.com/36973363/169056480-b296b637-ebf1-42d6-8a93-7602797bba34.png">


## Testing Instructions

 * Navigate to the homepage and verify the change in the Recent Meetings section

Handles #848 
