### PR TITLE
Alphabetize board reports on About page

### DIFF
--- a/councilmatic/settings_jurisdiction.py
+++ b/councilmatic/settings_jurisdiction.py
@@ -1,3 +1,5 @@
+from operator import itemgetter
+
 # These are all the settings that are specific to a jurisdiction
 
 ###############################
@@ -90,7 +92,7 @@ COMMITTEE_MEMBER_TITLE = 'Member'
 # this is for convenience, & used to populate a table
 # describing legislation types on the default about page template
 # the 'search_term' should be lowercase with spaces before and after backslashes
-LEGISLATION_TYPE_DESCRIPTIONS = [
+legislation_types = [
     {
         'name': 'Budget',
         'search_term': 'budget',
@@ -232,6 +234,9 @@ LEGISLATION_TYPE_DESCRIPTIONS = [
         'desc': "Formal information communication to the Board not requiring actions. We are in the process of importing Board Boxes to this website; in the meantime, please access Board Box items through the <a href='/archive-search' target='_blank'>Archive Search</a>."
     },
 ]
+
+# we want board report types to be in alphabetical order on Metro's About page
+LEGISLATION_TYPE_DESCRIPTIONS = sorted(legislation_types, key=itemgetter('name'))
 
 BILL_STATUS_DESCRIPTIONS = {
     'ADOPTED': {

--- a/councilmatic/settings_jurisdiction.py
+++ b/councilmatic/settings_jurisdiction.py
@@ -227,11 +227,12 @@ legislation_types = [
         'html_desc': True,
         'desc': 'Certain board actions require the adoption of a board resolution, usually financial and real estate transactions.',
     },
-    {   'name': 'Board Box',
+    {
+        'name': 'Board Box / Board Correspondence',
         'search_term': 'board box',
         'fa_icon': 'commenting-o',
         'html_desc': True,
-        'desc': "Formal information communication to the Board not requiring actions. We are in the process of importing Board Boxes to this website; in the meantime, please access Board Box items through the <a href='/archive-search' target='_blank'>Archive Search</a>."
+        'desc': 'Formal information communication from Metro staff to the Board, which does not require Board action. Historically, these items were called "Board Box"(es), because a physical box containing each month\'s items was delivered to the Board for review. Because these items are now delivered digitally, their "Board Report Type" designation is "Board Correspondence" so the nature of these items is more clear to the public. We are in the process of importing Board Boxes to this website; in the meantime, please access Board Box/Correspondence items through the <a href="/archive-search">Archive Search</a>. You can also access a directory of Board Correspondence from 2015 to present, by year, <a href="http://boardarchives.metro.net/BoardBox/">here</a>.'
     },
 ]
 

--- a/lametro/templates/lametro/about.html
+++ b/lametro/templates/lametro/about.html
@@ -94,7 +94,6 @@
         <p>Learn more about Metro Board of Directors meetings, and view meetings and agendas <a href="{% url 'events' %}">here</a>.</p>
 
         <h4>Types of Board Reports</h4>
-        <p>Below are the categories of Metro Board report activity:</p>
 
         {% include 'partials/component_bill_type_table.html' %}
 


### PR DESCRIPTION
## Overview

This PR alphabetizes Board Report types on Metro's About page. It also amends the description of Board Boxes.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="919" alt="Screen Shot 2022-06-22 at 4 02 04 PM" src="https://user-images.githubusercontent.com/36973363/175125887-93a6a9d2-7978-4743-84e8-46f902157ff3.png">


## Testing Instructions

 * Navigate to the About page and verify the changes

Handles #856 
