### PR TITLE
Only show approved minutes on Meetings & Agendas page

### DIFF
--- a/lametro/views.py
+++ b/lametro/views.py
@@ -283,9 +283,10 @@ class LAMetroEventsView(EventsView):
         day_grouper    = lambda x: (x.local_start_time.year, x.local_start_time.month, x.local_start_time.day)
 
         # We only want to display approved minutes
-        minutes_queryset = EventDocument.objects.select_related('event')\
-                                        .filter(note__icontains='minutes')\
-                                        .filter(event__extras__approved_minutes=True)
+        minutes_queryset = EventDocument.objects.filter(
+                event__extras__approved_minutes=True,
+                note__icontains='minutes'
+            )
 
         # If yes...
         if start_date_str and end_date_str:

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -284,8 +284,8 @@ class LAMetroEventsView(EventsView):
 
         # We only want to display approved minutes
         all_event_docs = EventDocument.objects.select_related('event')
-        minutes = [doc.id for doc in all_event_docs if doc.event.extras.get('approved_minutes')]
-        minutes_queryset = all_event_docs.filter(id__in=minutes)
+        approved_minutes = [doc.id for doc in all_event_docs if doc.event.extras.get('approved_minutes')]
+        minutes_queryset = all_event_docs.filter(id__in=approved_minutes)
 
         # If yes...
         if start_date_str and end_date_str:

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -283,9 +283,9 @@ class LAMetroEventsView(EventsView):
         day_grouper    = lambda x: (x.local_start_time.year, x.local_start_time.month, x.local_start_time.day)
 
         # We only want to display approved minutes
-        all_event_docs = EventDocument.objects.select_related('event')
-        approved_minutes = [doc.id for doc in all_event_docs if doc.event.extras.get('approved_minutes')]
-        minutes_queryset = all_event_docs.filter(id__in=approved_minutes)
+        minutes_queryset = EventDocument.objects.select_related('event')\
+                                        .filter(note__icontains='minutes')\
+                                        .filter(event__extras__approved_minutes=True)
 
         # If yes...
         if start_date_str and end_date_str:

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -282,7 +282,10 @@ class LAMetroEventsView(EventsView):
         end_date_str   = self.request.GET.get('to')
         day_grouper    = lambda x: (x.local_start_time.year, x.local_start_time.month, x.local_start_time.day)
 
-        minutes_queryset = EventDocument.objects.filter(note__icontains='minutes')
+        # We only want to display approved minutes
+        all_event_docs = EventDocument.objects.select_related('event')
+        minutes = [doc.id for doc in all_event_docs if doc.event.extras.get('approved_minutes')]
+        minutes_queryset = all_event_docs.filter(id__in=minutes)
 
         # If yes...
         if start_date_str and end_date_str:


### PR DESCRIPTION
## Overview

This PR ensures that only minutes that have been approved are displayed on the Meetings & Agendas page.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Navigate to Meetings & Agendas page and make sure that only approved minutes are displayed

Handles #854 
