### PR TITLE
Link federated search and open calendar links in new tab

### DIFF
--- a/lametro/templates/base.html
+++ b/lametro/templates/base.html
@@ -72,7 +72,7 @@
                             <a href="{% url 'lametro:search' %}">Board Reports</a>
                         </li>
                         <li>
-                            <a href="{% url 'lametro:archive-search' %}">Archive Search</a>
+                            <a href="https://mtasearch01.metro.net:23352/apps/boardarchives/">Archive Search</a>
                         </li>
                       </ul>
                     </li>

--- a/lametro/templates/lametro/index.html
+++ b/lametro/templates/lametro/index.html
@@ -72,7 +72,7 @@
                     </span>
                     Upcoming Meetings
                     <small>
-                        <a href="{% static 'pdf/fy23-committee-board-calendar.pdf' %}" class="btn btn-link">
+                        <a href="{% static 'pdf/fy23-committee-board-calendar.pdf' %}" target="_blank" class="btn btn-link">
                             <i class="fa fa-fw fa-download" aria-hidden="true"></i>
                             Download Fiscal Year 2023 event calendar (PDF)
                         </a>
@@ -108,7 +108,7 @@
                     </span>
                     Recent Meetings
                     <small>
-                        <a href="{% static 'pdf/fy23-committee-board-calendar.pdf' %}" class="btn btn-link">
+                        <a href="{% static 'pdf/fy23-committee-board-calendar.pdf' %}" target="_blank" class="btn btn-link">
                             <i class="fa fa-fw fa-download" aria-hidden="true"></i>
                             Download Fiscal Year 2023 event calendar (PDF)
                         </a>


### PR DESCRIPTION
## Overview

This PR routes the "Archive Search" link in the navbar to Metro's federated search and opens PDF calendar links on the homepage in a new tab.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Navigate to homepage and verify that calendar links open in a new tab
 * Verify that archive search link in navbar sends users to federated search

Handles #864 #863 
