### PR TITLE
Add Displayed Status column to Board Report Statuses table on About page

### DIFF
--- a/lametro/templates/partials/board_report_statuses.html
+++ b/lametro/templates/partials/board_report_statuses.html
@@ -2,6 +2,7 @@
     <thead>
         <tr>
             <th>Status</th>
+            <th class="desktop-only">Displayed Status</th>
             <th class="desktop-only">Description</th>
         </tr>
     </thead>
@@ -9,12 +10,11 @@
     {% for status, obj in BILL_STATUS_DESCRIPTIONS.items %}
         <tr>
             <td>
-                <p class='nowrap'>
-                    {% if obj.search_term %}
-                    <a href='/search/?selected_facets=inferred_status_exact%3A{{obj.search_term}}'>{{status | title}}</a>
-                    {% else %}
-                    <p>{{status | title}}</p>
-                    {% endif %}
+                <p class="nowrap desktop-only">
+                    {{status | title}}
+                </p>
+                <p class="nowrap non-desktop-only">
+					<a href='/search/?selected_facets=inferred_status_exact%3A{{obj.search_term}}'>{{status | title}}</a>
                 </p>
                 <div class="non-desktop-only">
                     <p>
@@ -23,8 +23,17 @@
                 </div>
             </td>
             <td class="desktop-only">
+                <p class="nowrap">
+                    {% if obj.search_term %}
+					<a href='/search/?selected_facets=inferred_status_exact%3A{{obj.search_term}}'>{{obj.search_term}}</a>
+                    {% else %}
+                    <p>N/A</p>
+                    {% endif %}
+                </p>
+			</td>
+            <td class="desktop-only">
                 <p>
-                    <p>{{obj.definition}}</p>
+                    {{obj.definition}}
                 </p>
             </td>
         </tr>


### PR DESCRIPTION
## Overview

This PR adds a Displayed Status column to the Board Report Statuses table.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="917" alt="Screen Shot 2022-06-27 at 12 19 47 PM" src="https://user-images.githubusercontent.com/36973363/175988687-14c54437-2674-4c00-a675-a50afc06f455.png">


### Notes

For mobile view, I kept the current table layout. If we want to display Displayed Status information without adding an extra column, we could add an extra line of text with that information.

<img width="468" alt="Screen Shot 2022-06-27 at 12 20 00 PM" src="https://user-images.githubusercontent.com/36973363/175988691-bd8ba96f-3c09-4894-a952-31a6492e802a.png">

## Testing Instructions

 * Navigate to the about page and view the Board Report Statuses table

Handles #777 
