### PR TITLE
Update link to archives on Board Reports search

### DIFF
--- a/lametro/templates/partials/empty_search_message.html
+++ b/lametro/templates/partials/empty_search_message.html
@@ -1,5 +1,5 @@
 <p>
-  This site has Board Reports and Agendas from June 2015 to present. If you're searching for something older, you can browse the <a href="{% url 'lametro:archive-search' %}">Archive Search</a>.
+  This site has Board Reports and Agendas from June 2015 to present. If you're searching for something older, you can browse the <a href="https://mtasearch01.metro.net:23352/apps/boardarchives/">Archive Search</a>.
 </p>
 <p>We'd be happy to help you find what you're looking for! Contact us at
   <a href="mailto:boardreport@metro.net">boardreport@metro.net</a>


### PR DESCRIPTION
## Overview

This PR updates the link to search the archives when a Board Report search returns no results.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs


## Testing Instructions

 * Navigate to localhost:8001/search/
 * Search for a random string and verify that link to archives has been updated

Handles #876 
