### PR TITLE
Fix current meeting buttons

### DIFF
--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -375,3 +375,8 @@ hr .events-line {
 	visibility: hidden; 
 	pointer-events: none;
 }
+
+.current-meeting-info {
+	margin-top: 10px;
+	margin-left: 5px;
+}

--- a/lametro/templates/partials/meeting_details_current.html
+++ b/lametro/templates/partials/meeting_details_current.html
@@ -82,46 +82,32 @@
                         <i class="fa fa-fw fa-calendar-o"></i> {{ current_meeting.first.start_time | date:"D n/d/Y"}}<br/>
                         <i class="fa fa-fw fa-clock-o"></i> {{ current_meeting.first.start_time | date:"g:i a"}}<br/>
                         <i class="fa fa-fw fa-map-marker"></i> {{ current_meeting.first.location.name}}<br />
+					  <br />
                     </p>
 
-                    {% if current_meeting.first.documents.all %}
-                        <div class="text-center">
-                            <p>
-                                <a class="btn btn-teal" id="pdf-download-link" target='_blank' href='{{ current_meeting.first.documents.all|find_agenda_url }}'>
-                                    <i class='fa fa-fw fa-download'></i>
-                                    Get Agenda PDF
-                                </a>
-                            </p>
-                        </div>
-                    {% endif %}
                 </div>
-            </div>
 
             <!-- Buttons -->
-            <div class="row">
-                <div class="col-md-12 text-center">
-                    <p>
-                        <a class="btn btn-salmon" href="{{ current_meeting.first.english_live_media_url }}" target="_blank" style="margin-top: 10px; margin-left: 5px;">
-                            <i class="fa fa-headphones" aria-hidden="true"></i>
-                            Watch in English
-                        </a>
+			<div class="text-center" style="display:inline-block;">
+			  <div class="btn-group btn-group-sm current-meeting-info" role="toolbar">
+				<a class="btn btn-salmon" href="{{ current_meeting.first.english_live_media_url }}" target="_blank" >
+				  <i class="fa fa-headphones" aria-hidden="true"></i>
+				  Watch in English
+				</a>
 
-                        {% if bilingual %}
-                            <a class="btn btn-salmon" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank" style="margin-top: 10px; margin-left: 5px;">
-                                <i class="fa fa-headphones" aria-hidden="true"></i>
-                                Ver en Español
-                            </a>
-                        {% endif %}
+				<a class="btn btn-salmon" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank" >
+				  <i class="fa fa-headphones" aria-hidden="true"></i>
+				  Ver en Español
+				</a>
+			  </div>
 
-                        {% if USING_ECOMMENT %}
-                            <a class="btn btn-salmon" href="{{ current_meeting.first.ecomment_url }}" target="_blank" style="margin-top: 10px; margin-left: 5px;">
-                                <i class='fa fa-fw fa-external-link'></i>
-                                Go to public comment
-                            </a>
-                        {% endif %}
-                    </p>
-                </div>
-            </div>
+			  <a class="btn btn-sm btn-teal current-meeting-info" id="pdf-download-link" target='_blank' href='/'>
+				<i class='fa fa-fw fa-download'></i>
+				Get Agenda PDF
+			  </a>
+			</p>
+			</div>
+			</div>
 
         {% endif %}
     </div>

--- a/lametro/templates/partials/meeting_details_current.html
+++ b/lametro/templates/partials/meeting_details_current.html
@@ -82,33 +82,44 @@
                         <i class="fa fa-fw fa-calendar-o"></i> {{ current_meeting.first.start_time | date:"D n/d/Y"}}<br/>
                         <i class="fa fa-fw fa-clock-o"></i> {{ current_meeting.first.start_time | date:"g:i a"}}<br/>
                         <i class="fa fa-fw fa-map-marker"></i> {{ current_meeting.first.location.name}}<br />
-					  <br />
                     </p>
-
                 </div>
 
             <!-- Buttons -->
-			<div class="text-center" style="display:inline-block;">
-			  <div class="btn-group btn-group-sm current-meeting-info" role="toolbar">
-				<a class="btn btn-salmon" href="{{ current_meeting.first.english_live_media_url }}" target="_blank" >
-				  <i class="fa fa-headphones" aria-hidden="true"></i>
-				  Watch in English
-				</a>
+            <div class="text-center">
+                <div style="display:inline-block;">
+				  <div class="btn-group btn-group-sm current-meeting-info" role="toolbar">
+					<a class="btn btn-salmon" href="{{ current_meeting.first.english_live_media_url }}" target="_blank" >
+					  <i class="fa fa-headphones" aria-hidden="true"></i>
+					  Watch in English
+					</a>
 
-				<a class="btn btn-salmon" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank" >
-				  <i class="fa fa-headphones" aria-hidden="true"></i>
-				  Ver en Español
-				</a>
-			  </div>
+					{% if bilingual %}
+					<a class="btn btn-salmon" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank">
+					  <i class="fa fa-headphones" aria-hidden="true"></i>
+					  Ver en Español
+					</a>
+					{% endif %}
 
-			  <a class="btn btn-sm btn-teal current-meeting-info" id="pdf-download-link" target='_blank' href='/'>
-				<i class='fa fa-fw fa-download'></i>
-				Get Agenda PDF
-			  </a>
-			</p>
-			</div>
-			</div>
+				  </div>
 
+				  {% if USING_ECOMMENT %}
+				  <a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.ecomment_url }}" target="_blank">
+					<i class='fa fa-fw fa-external-link'></i>
+					Go to public comment
+				  </a>
+				  {% endif %}
+
+				  {% if current_meeting.first.documents.all %}
+					<a class="btn btn-sm btn-teal current-meeting-info" id="pdf-download-link" target='_blank' href='{{ current_meeting.first.documents.all|find_agenda_url }}'>
+					  <i class='fa fa-fw fa-download'></i>
+					  Get Agenda PDF
+					</a>
+				  {% endif %}
+
+                </div>
+            </div>
+		  </div>
         {% endif %}
     </div>
 </div>

--- a/lametro/templates/partials/meeting_details_current.html
+++ b/lametro/templates/partials/meeting_details_current.html
@@ -85,41 +85,41 @@
                     </p>
                 </div>
 
-            <!-- Buttons -->
-            <div class="text-center">
-                <div style="display:inline-block;">
-				  <div class="btn-group btn-group-sm current-meeting-info" role="toolbar">
-					<a class="btn btn-salmon" href="{{ current_meeting.first.english_live_media_url }}" target="_blank" >
-					  <i class="fa fa-headphones" aria-hidden="true"></i>
-					  Watch in English
-					</a>
+				<!-- Buttons -->
+				<div class="text-center">
+					<div style="display:inline-block;">
+					  <div class="btn-group btn-group-sm current-meeting-info" role="toolbar">
+						<a class="btn btn-salmon" href="{{ current_meeting.first.english_live_media_url }}" target="_blank" >
+						  <i class="fa fa-headphones" aria-hidden="true"></i>
+						  Watch in English
+						</a>
 
-					{% if bilingual %}
-					<a class="btn btn-salmon" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank">
-					  <i class="fa fa-headphones" aria-hidden="true"></i>
-					  Ver en Español
-					</a>
-					{% endif %}
+						{% if bilingual %}
+						<a class="btn btn-salmon" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank">
+						  <i class="fa fa-headphones" aria-hidden="true"></i>
+						  Ver en Español
+						</a>
+						{% endif %}
 
-				  </div>
+					  </div>
 
-				  {% if USING_ECOMMENT %}
-				  <a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.ecomment_url }}" target="_blank">
-					<i class='fa fa-fw fa-external-link'></i>
-					Go to public comment
-				  </a>
-				  {% endif %}
+					  {% if USING_ECOMMENT %}
+					  <a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.ecomment_url }}" target="_blank">
+						<i class='fa fa-fw fa-external-link'></i>
+						Go to public comment
+					  </a>
+					  {% endif %}
 
-				  {% if current_meeting.first.documents.all %}
-					<a class="btn btn-sm btn-teal current-meeting-info" id="pdf-download-link" target='_blank' href='{{ current_meeting.first.documents.all|find_agenda_url }}'>
-					  <i class='fa fa-fw fa-download'></i>
-					  Get Agenda PDF
-					</a>
-				  {% endif %}
+					  {% if current_meeting.first.documents.all %}
+						<a class="btn btn-sm btn-teal current-meeting-info" id="pdf-download-link" target='_blank' href='{{ current_meeting.first.documents.all|find_agenda_url }}'>
+						  <i class='fa fa-fw fa-download'></i>
+						  Get Agenda PDF
+						</a>
+					  {% endif %}
 
-                </div>
-            </div>
-		  </div>
+					</div>
+				</div>
+			</div>
         {% endif %}
     </div>
 </div>

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -73,7 +73,7 @@ class LAMetroIndexView(IndexView):
 
         extra['upcoming_board_meetings'] = self.event_model.upcoming_board_meetings()[:2]
         extra['most_recent_past_meetings'] = self.event_model.most_recent_past_meetings()
-        extra['current_meeting'] = self.event_model.objects.filter(id='ocd-event/7e60bf01-617f-400a-98fb-b82fe017dd29')
+        extra['current_meeting'] = self.event_model.current_meeting()
         extra['bilingual'] = bool([e for e in extra['current_meeting'] if e.bilingual])
         extra['USING_ECOMMENT'] = settings.USING_ECOMMENT
 

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -73,7 +73,7 @@ class LAMetroIndexView(IndexView):
 
         extra['upcoming_board_meetings'] = self.event_model.upcoming_board_meetings()[:2]
         extra['most_recent_past_meetings'] = self.event_model.most_recent_past_meetings()
-        extra['current_meeting'] = self.event_model.current_meeting()
+        extra['current_meeting'] = self.event_model.objects.filter(id='ocd-event/7e60bf01-617f-400a-98fb-b82fe017dd29')
         extra['bilingual'] = bool([e for e in extra['current_meeting'] if e.bilingual])
         extra['USING_ECOMMENT'] = settings.USING_ECOMMENT
 


### PR DESCRIPTION
## Overview

This PR fixes the alignment of buttons that appear under ongoing meetings on the homepage. 

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="1237" alt="Screen Shot 2022-07-29 at 3 30 59 PM" src="https://user-images.githubusercontent.com/36973363/182618997-63cfd17b-4229-4246-baef-825629843af6.png">
<img width="1028" alt="Screen Shot 2022-07-29 at 3 31 49 PM" src="https://user-images.githubusercontent.com/36973363/182619007-a2db787a-7b8e-4ef2-ad6a-e151f63fa3e7.png">


## Testing Instructions

Your local app needs to think a meeting is ongoing to display the changes. One way to do this is to manually pass a meeting to the homepage's view. You can do that by shelling into your app with `docker-compose run --rm app python manage.py shell` and grabbing the `id` of an `LAMetroEvent`. Then, set `extra["current_meeting"]` in `LAMetroIndexView.extra_content` with `LAMetroEvent.objects.get(id=[id-of-your-chosen-event])`.

After, verify the changes on the homepage. Some buttons (e.g. spanish and agenda pdf) appear conditionally so you'll need to remove some of that logic in the template to view them.

Handles #816 
