### PR TITLE
Fix Board Report type search links on About page

### DIFF
--- a/councilmatic/settings_jurisdiction.py
+++ b/councilmatic/settings_jurisdiction.py
@@ -94,7 +94,7 @@ legislation_types = [
         'desc': 'A plan of financial operations for a given period, including proposed expenditures, authorized staffing levels, and a proposed means of financing them. Metro follows a July 1 to June 30 Fiscal Year.  Its annual budgets are typically approved by the Board after a public hearing in May of each year. Individual capital projects over $5 million have a Life of Project (LOP) budget estimate reviewed by the Board of Directors.',
     },
     {
-        'name': 'Fare/Tariff/Service Change',
+        'name': 'Fare / Tariff / Service Change',
         'search_term': 'fare / tariff / service change',
         'html_id': 'fare-tariff-service-change',
         'fa_icon': 'dollar',
@@ -206,7 +206,7 @@ legislation_types = [
         'desc': 'The permanent official legal record of the business transacted, resolutions adopted, votes taken, and general proceedings of the Board of Directors. ',
     },
     {
-        'name': 'Motion/Motion Response',
+        'name': 'Motion / Motion Response',
         'search_term': 'motion / motion response',
         'html_id': 'motion-response',
         'fa_icon': 'bullhorn',
@@ -214,7 +214,7 @@ legislation_types = [
         'desc': 'These are issues raised by Board Members during meetings. Motions are usually proposed in writing by one or more Board Members. Motions include background information and a specific directive to staff after the words “I therefore move”, and then voted on. When adopted by the Board with a majority vote, staff is given a specific timeframe to research and respond back.',
     },
     {
-        'name': 'Oral Report/Presentation',
+        'name': 'Oral Report / Presentation',
         'search_term': 'oral report / presentation',
         'html_id': 'oral-report-presentation',
         'fa_icon': 'bullhorn',

--- a/lametro/templates/base.html
+++ b/lametro/templates/base.html
@@ -148,14 +148,14 @@
                     $target = $target.parent();
                 }
 
-                if ($target.attr('href') != '#') {
-                    var targetUrl = new URL(window.location.origin + $target.attr('href'));
-                } else {
+                if ($target.hasClass('filter-value')) {
                     // Search filters have an href of "#". There is logic below
                     // to construct the correct URL. Start with the current URL
                     // as a basis for this construction.
                     var targetUrl = new URL(window.location.href);
-                }
+                } else {
+                    var targetUrl = new URL(window.location.origin + $target.attr('href'));
+				}
 
                 var isSearch = ['/search', '/search/'].indexOf(targetUrl.pathname) >= 0;
 

--- a/lametro/templates/partials/component_bill_type_table.html
+++ b/lametro/templates/partials/component_bill_type_table.html
@@ -1,3 +1,5 @@
+{% load lametro_extras %}
+
 <table class="table" id="legislation-types">
     <thead>
         <tr>
@@ -11,7 +13,11 @@
 			<td >
                 <p class="nowrap" id="{{ leg_type.html_id }}">
                     <i class="fa fa-fw fa-{{leg_type.fa_icon}}"></i>
-                    <a href="/search/?selected_facets=bill_type_exact%3A{{leg_type.search_term}}">{{leg_type.name}}</a>
+					{% if leg_type.name == 'Board Box / Board Correspondence' %}
+						<a href="https://mtasearch01.metro.net:23352/apps/boardarchives/?tab=boardbox">{{leg_type.name}}</a>
+					{% else %}
+						<a href="/search/?selected_facets=bill_type_exact%3A{{leg_type.name|query_encode}}">{{leg_type.name}}</a>
+					{% endif %}
                 </p>
 
                 <div class="non-desktop-only">

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -244,7 +244,7 @@ def get_list(querydict, key):
 @register.filter
 def get_bill_type_link(bill_type):
     for legislation_type in LEGISLATION_TYPE_DESCRIPTIONS:
-        if legislation_type['search_term'].title() == bill_type:
+        if legislation_type['search_term'].upper() == bill_type.upper():
             return f'/about#{legislation_type["html_id"]}'
 
     return ''

--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -244,7 +244,11 @@ def get_list(querydict, key):
 @register.filter
 def get_bill_type_link(bill_type):
     for legislation_type in LEGISLATION_TYPE_DESCRIPTIONS:
-        if legislation_type['search_term'].upper() == bill_type.upper():
+        if legislation_type['search_term'].title() == bill_type:
             return f'/about#{legislation_type["html_id"]}'
 
     return ''
+
+@register.filter
+def query_encode(query):
+    return urllib.parse.quote_plus(query)


### PR DESCRIPTION
## Overview

This PR fixes search links in the 'Types of Board Reports' table on the About page.

It also points the Board Box link in the table to the Archive Search for now as we determine which Board Box should be public.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

#### URL Encoding

An interesting point here is that form data in query parameters in URLs use `+` to encode spaces. Django's `urlencode` uses standard percent encoding so using it to escape `bill_type` in search URLs would cause errors. 

I found that Firefox automatically escapes form data in URLs correctly but I thought it'd be good form to pass browsers properly escaped URLs so I made a template tag to use `urllib.quote_plus()`.

#### CAPTCHAs

The login in the CAPTCHA script in `base.html` was causing strange navbar behavior. Since navbar dropdowns are also links with `#` for their `href`s, the page was reloading every time a user clicked on them.


## Testing Instructions

 * Navigate to the About page and verify that links to board report types render search results correctly
 * Verify that the navbar behaves properly when you're on the search page
 * Verify that the Board Box link sends you to the archive search

Handles #886
