### PR TITLE
Define 'link' variable in find_agenda_url Django filter

### DIFF
--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -158,7 +158,7 @@ def find_agenda_url(all_documents):
 
     pdf_url = [('static/' + link.url) for doc in all_documents
                if doc.note == 'Event Document - Manual upload PDF'
-               for url in doc.links.all()]
+               for link in doc.links.all()]
 
     valid_urls += pdf_url
 


### PR DESCRIPTION
## Overview

See title.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

Handles #890 
