### PR TITLE
Use separate buttons for current meeting language options

### DIFF
--- a/lametro/templates/partials/meeting_details_current.html
+++ b/lametro/templates/partials/meeting_details_current.html
@@ -88,34 +88,34 @@
 				<!-- Buttons -->
 				<div class="text-center">
 					<div style="display:inline-block;">
-					  <div class="btn-group btn-group-sm current-meeting-info" role="toolbar">
-						<a class="btn btn-salmon" href="{{ current_meeting.first.english_live_media_url }}" target="_blank" >
-						  <i class="fa fa-headphones" aria-hidden="true"></i>
-						  Watch in English
-						</a>
+						<div class="btn-group btn-group-sm current-meeting-info" role="toolbar">
+							<a class="btn btn-salmon" href="{{ current_meeting.first.english_live_media_url }}" target="_blank" >
+								<i class="fa fa-headphones" aria-hidden="true"></i>
+								Watch in English
+							</a>
 
-						{% if bilingual %}
-						<a class="btn btn-salmon" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank">
-						  <i class="fa fa-headphones" aria-hidden="true"></i>
-						  Ver en Español
-						</a>
+							{% if bilingual %}
+								<a class="btn btn-salmon" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank">
+									<i class="fa fa-headphones" aria-hidden="true"></i>
+									Ver en Español
+								</a>
+							{% endif %}
+
+						</div>
+
+						{% if USING_ECOMMENT %}
+							<a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.ecomment_url }}" target="_blank">
+								<i class='fa fa-fw fa-external-link'></i>
+								Go to public comment
+							</a>
 						{% endif %}
 
-					  </div>
-
-					  {% if USING_ECOMMENT %}
-					  <a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.ecomment_url }}" target="_blank">
-						<i class='fa fa-fw fa-external-link'></i>
-						Go to public comment
-					  </a>
-					  {% endif %}
-
-					  {% if current_meeting.first.documents.all %}
-						<a class="btn btn-sm btn-teal current-meeting-info" id="pdf-download-link" target='_blank' href='{{ current_meeting.first.documents.all|find_agenda_url }}'>
-						  <i class='fa fa-fw fa-download'></i>
-						  Get Agenda PDF
-						</a>
-					  {% endif %}
+						{% if current_meeting.first.documents.all %}
+							<a class="btn btn-sm btn-teal current-meeting-info" id="pdf-download-link" target='_blank' href='{{ current_meeting.first.documents.all|find_agenda_url }}'>
+								<i class='fa fa-fw fa-download'></i>
+								Get Agenda PDF
+							</a>
+						{% endif %}
 
 					</div>
 				</div>

--- a/lametro/templates/partials/meeting_details_current.html
+++ b/lametro/templates/partials/meeting_details_current.html
@@ -89,14 +89,14 @@
 				<div class="text-center">
 					<div style="display:inline-block;">
 						<a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.english_live_media_url }}" target="_blank" >
-						  <i class="fa fa-headphones" aria-hidden="true"></i>
-						  Watch in English
+							<i class="fa fa-headphones" aria-hidden="true"></i>
+							Watch in English
 						</a>
 
 						{% if bilingual %}
 						<a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank">
-						  <i class="fa fa-headphones" aria-hidden="true"></i>
-						  Ver en Español
+							<i class="fa fa-headphones" aria-hidden="true"></i>
+							Ver en Español
 						</a>
 						{% endif %}
 

--- a/lametro/templates/partials/meeting_details_current.html
+++ b/lametro/templates/partials/meeting_details_current.html
@@ -88,20 +88,17 @@
 				<!-- Buttons -->
 				<div class="text-center">
 					<div style="display:inline-block;">
-						<div class="btn-group btn-group-sm current-meeting-info" role="toolbar">
-							<a class="btn btn-salmon" href="{{ current_meeting.first.english_live_media_url }}" target="_blank" >
-								<i class="fa fa-headphones" aria-hidden="true"></i>
-								Watch in English
-							</a>
+						<a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.english_live_media_url }}" target="_blank" >
+						  <i class="fa fa-headphones" aria-hidden="true"></i>
+						  Watch in English
+						</a>
 
-							{% if bilingual %}
-								<a class="btn btn-salmon" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank">
-									<i class="fa fa-headphones" aria-hidden="true"></i>
-									Ver en Español
-								</a>
-							{% endif %}
-
-						</div>
+						{% if bilingual %}
+						<a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.spanish_live_media_url }}" target="_blank">
+						  <i class="fa fa-headphones" aria-hidden="true"></i>
+						  Ver en Español
+						</a>
+						{% endif %}
 
 						{% if USING_ECOMMENT %}
 							<a class="btn btn-sm btn-salmon current-meeting-info" href="{{ current_meeting.first.ecomment_url }}" target="_blank">


### PR DESCRIPTION
## Overview

This PR implements separate buttons for current meeting language options instead of using a button group.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="1190" alt="Screen Shot 2022-08-29 at 10 46 21 AM" src="https://user-images.githubusercontent.com/36973363/187229648-9c27fbb6-5d00-4424-b85f-6081663bda2e.png">


## Testing Instructions

 * Hard code `LAMetroIndexView.extra_content.extra['current_meeting']` with a meeting
 * Remove the `{% if bilingual %}` tag on L96 of `meeting_details_current.html`
 * Verify that the buttons render separately

Handles #878 
