### PR TITLE
Fix remove facet bug on search pages

### DIFF
--- a/lametro/templates/base.html
+++ b/lametro/templates/base.html
@@ -148,7 +148,7 @@
                     $target = $target.parent();
                 }
 
-				const isSearchFilter = $target.hasClass('filter-value') || $target.hasClass('remove-filter-value')
+		const isSearchFilter = $target.hasClass('filter-value') || $target.hasClass('remove-filter-value')
                 if (isSearchFilter) {
                     // Search filters have an href of "#". There is logic below
                     // to construct the correct URL. Start with the current URL

--- a/lametro/templates/base.html
+++ b/lametro/templates/base.html
@@ -148,7 +148,8 @@
                     $target = $target.parent();
                 }
 
-                if ($target.hasClass('filter-value')) {
+				const isSearchFilter = $target.hasClass('filter-value') || $target.hasClass('remove-filter-value')
+                if (isSearchFilter) {
                     // Search filters have an href of "#". There is logic below
                     // to construct the correct URL. Start with the current URL
                     // as a basis for this construction.


### PR DESCRIPTION
## Overview

This PR fixes a bug that prevented users from removing a selected facet from their search filter.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs


## Testing Instructions

 * Navigate to the search page and execute a search
 * Verify that you can filter results by both adding and removing facets

Handles #893 
