### PR TITLE
Prevent horizontal scrolling on homepage for mobile

### DIFF
--- a/lametro/templates/index/index.html
+++ b/lametro/templates/index/index.html
@@ -108,18 +108,26 @@
         </div>
         <div class="row-fluid">
             <div class="col-sm-10 col-sm-offset-1">
-                <h2>
+                <h2 style="display: inline-block;">
                     <span class="non-mobile-only">
                         <i class="fa fa-calendar-check-o" aria-hidden="true"></i>
                     </span>
                     Recent Meetings
-                    <small>
+                </h2>
+                <small class="pull-right" style="display: inline-block;">
+                    <p>
+                        Download event calendar:
                         <a href="{% static 'pdf/fy23-committee-board-calendar.pdf' %}" target="_blank" class="btn btn-link">
                             <i class="fa fa-fw fa-download" aria-hidden="true"></i>
-                            Download Fiscal Year 2023 event calendar (PDF)
+                            Fiscal Year 2023 (PDF)
                         </a>
-                    </small>
-                </h2>
+                        <a href="{% static 'pdf/fy24-committee-board-calendar.pdf' %}" target="_blank" class="btn btn-link">
+                            <i class="fa fa-fw fa-download" aria-hidden="true"></i>
+                            Fiscal Year 2024 (PDF)
+                        </a>
+                    </p>
+                </small>
+
                 {% if most_recent_past_meetings %}
                     {% for event in most_recent_past_meetings %}
                         {% include "index/_past_event_item.html" %}


### PR DESCRIPTION
## Overview

There was a download link under the Recent Meetings heading that was long enough to cause horizontal scrolling on mobile. This branch copies the structure of the download links under Upcoming Meetings, to both add the 2024 calendar and shorten those links, preventing scrolling

### Demo

Before
![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/7a80a1b4-3a80-4366-902f-e57e1b13b72b)

After
![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/930ec89b-c94e-44a9-8683-b41f3767b39a)

## Testing Instructions

 * Resize window on or use browserstack to navigate to the homepage
 * Confirm that the page cannot scroll horizontally
