### PR TITLE
Ensure link to merged board room rules section scrolls appropriately

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ docker-compose up -d
 
 Note that you can omit the `-d` flag to follow the application and service logs. If you prefer a quieter environment, you can view one log stream at a time with `docker-compose logs -f SERVICE_NAME`, where `SERVICE_NAME` is the name of one of the services defined in `docker-compose.yml`, e.g., `app`, `postgres`, etc.
 
-When the command exits (`-d`) or your logs indicate that your app is up and running, visit http://localhost:8000 to visit your shiny, new local application!
+When the command exits (`-d`) or your logs indicate that your app is up and running, visit http://localhost:8001 to visit your shiny, new local application!
 
 ### Load in the data
 

--- a/lametro/static/css/city_custom.css
+++ b/lametro/static/css/city_custom.css
@@ -441,3 +441,7 @@ hr .events-line {
 textarea#id_description {
     resize: vertical;
 }
+
+.scroll-anchor {
+    scroll-margin-top: 80px;
+}

--- a/lametro/templates/about/about.html
+++ b/lametro/templates/about/about.html
@@ -39,6 +39,9 @@
                     <a href="#about-la-metro">What is the Metro Board of Directors, and how does it work?</a>
                 </li>
                 <li>
+                    <a href="#procedures">Board Room Rules and Procedures</a>
+                </li>
+                <li>
                     <a href="#visit">Visit Metro Headquarters Building</a>
                 </li>
                 <li>
@@ -86,7 +89,7 @@
         <h4>Board Meetings</h4>
         <p>Learn more about Metro Board of Directors meetings, and view meetings and agendas <a href="{% url 'events' %}">here</a>.</p>
 
-				<h4>Board Room Rules and Procedures</h4>
+				<h4 id="procedures" class="scroll-anchor">Board Room Rules and Procedures</h4>
                 <p>Metro Board follows specific procedures to hold meetings and organize its members.</p>
                 <p>
                     <a href="{% static 'pdf/Board-Rules-Procedures.pdf' %}" target="_blank" aria-label="Read about all Metro Rules and Procedures. - pdf opens in a new tab">


### PR DESCRIPTION
## Overview

This branch uses the `scroll-margin-top` css property to ensure that clicking the table of contents link for the new Board Room Rules and Procedures section properly scrolls to show the the heading. Otherwise, the heading would be hidden behind the nav. Also a very small update to the readme concerning the link that leads to the app during local dev.

- Connects #1097

### Demo

Scroll without new property
![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/795fc344-43de-491d-b266-f2de4a3c32cf)

<hr>

Scroll with new property
![image](https://github.com/Metro-Records/la-metro-councilmatic/assets/114717958/de485af6-e071-4748-8b46-3979d58e0847)

### Notes

That's a cool property I didn't know about. It's pretty [widely supported](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top#browser_compatibility) too.

## Testing Instructions

 * Head to the About Us page
 * Click the Board Room Rules and Procedures link in the table of contents
 * Confirm that the entirety of the section scrolls into view
