### PR TITLE
Small fix to smartlogic/heroku exception handling

### DIFF
--- a/lametro/exceptions.py
+++ b/lametro/exceptions.py
@@ -22,7 +22,7 @@ class HerokuRequestError(Exception):
             self.message = (
                 f'Request failed for the following reason: {response.json()["message"]}'
             )
-        except JSONDecodeError:
+        except (JSONDecodeError, KeyError):
             self.message = (
                 "Request failed for the following reason: "
                 + f"{response.status_code} - {response.reason}"

--- a/smartlogic/exceptions.py
+++ b/smartlogic/exceptions.py
@@ -5,7 +5,7 @@ class RequestFailed(Exception):
     def __init__(self, response):
         try:
             self.message = f'Request failed for the following reason: {response.json()["error_description"]}'
-        except JSONDecodeError:
+        except (JSONDecodeError, KeyError):
             self.message = f"Request failed for the following reason: {response.status_code} - {response.reason}"
         self.status_code = response.status_code
         self.reason = response.reason


### PR DESCRIPTION
## Overview

Quick fix to ensure that when a request to Heroku or Smartlogic fails, that we get the error in whichever way it is sent to us.

In the related sentry issue, the error was caused because the response was json serializable, but just didn't have the field `error_description`. So I added a `KeyError` catch to the try blocks responsible for that.

- [Related Sentry issue](https://datamade.sentry.io/issues/6789966976/?alert_rule_id=1046323&alert_type=issue&environment=heroku-prod&notification_uuid=17c2a898-0a77-41ee-9624-4a7563a61fdb&project=2131912&referrer=slack)
