### PR TITLE
Lift relevant results when sorting search results by date

### DIFF
--- a/lametro/views.py
+++ b/lametro/views.py
@@ -689,11 +689,11 @@ class LAMetroCouncilmaticFacetedSearchView(CouncilmaticFacetedSearchView):
                     if el == "date":
                         if dataDict.get("order_by") == ["asc"]:
                             kwargs["searchqueryset"] = sqs.order_by(
-                                "last_action_date", "-score"
+                                "last_action_date", "-_score"
                             )
                         else:
                             kwargs["searchqueryset"] = sqs.order_by(
-                                "-last_action_date", "-score"
+                                "-last_action_date", "-_score"
                             )
                     if el == "title":
                         if dataDict.get("order_by") == ["desc"]:


### PR DESCRIPTION
## Overview

When sorting board report search results by date, this branch then sorts that queryset by each result's score. 

This is still beholden to how Elasticsearch scores results so some searches may continue to raise results with titles that seem less relevant. But results with relevant titles now show up closer to the top of stack of results with the same date more often, instead of floating somewhere in the middle.

- Connects #986

### Demo
Below are two examples of the same search for `Monthly Update on Public Safety` after filtering the results by Date

Searching my local db **before** this change (second to last result for that date):
<img width="883" height="726" alt="image" src="https://github.com/user-attachments/assets/251d1581-9d61-484a-b93a-54ca36c4e083" />

---

Searching my local db **after** this change (bumped up to first result for the date):
<img width="737" height="531" alt="image" src="https://github.com/user-attachments/assets/2f987f2f-202e-4a53-b830-970fdff3ead9" />

### Notes
For testing: There is a bug that makes review apps and staging crash when sorting by date and viewing the second page of results. Until that is resolved, we'll need to test this pr by either sticking to results on the first page, or by pulling this down and populating your local db and search index.

My local elasticsearch instance was acting up when testing/developing this. When my existing search container was brought up after having been stopped, it would just hang indefinitely. After researching and pairing, the solution really was to bring down all my metro volumes, rebuild them, run a bill scrape _and_ an event scrape for the same window (that way bills aren't incorrectly marked as restricted and actually show up in the search), and update the index. Then I was able to successfully dev/test until I brought my containers down again.
## Testing Instructions
* Perform a search for a board report which shares a date with others
* Sort results by date
* Find your target board report within the results, and confirm that it is the first of the results with that date
