### PR TITLE
Add workflows for notifying translation suite

### DIFF
--- a/.github/workflows/daily_scheduler.yml
+++ b/.github/workflows/daily_scheduler.yml
@@ -1,0 +1,20 @@
+name: Daily translation notifications dispatcher
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 23 * * *" # Runs every day an hour before midnight UTC
+
+jobs:
+  staging:
+    uses: ./.github/workflows/notify_translations.yml
+    with:
+      environment: staging
+    secrets: inherit
+
+  # production:
+  #   uses: ./.github/workflows/run_translation.yml
+  #   with:
+  #     environment: production
+  #   secrets: inherit

--- a/.github/workflows/daily_scheduler.yml
+++ b/.github/workflows/daily_scheduler.yml
@@ -1,7 +1,6 @@
 name: Daily translation notifications dispatcher
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "0 23 * * *" # Runs every day an hour before midnight UTC

--- a/.github/workflows/notify_translations.yml
+++ b/.github/workflows/notify_translations.yml
@@ -1,0 +1,50 @@
+name: Run translation ETL
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deployment environment"
+        required: true
+        type: choice
+        default: staging
+        options:
+          - staging
+          - production
+
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+        required: true
+
+env:
+  TRANSLATION_SUITE_URL: ${{ secrets.TRANSLATION_SUITE_URL }}
+  TRANSLATION_API_KEY: ${{ secrets.TRANSLATION_API_KEY }}
+  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+jobs:
+  build-notifications:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    container:
+      image: ghcr.io/metro-records/la-metro-councilmatic:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Build notifications
+        run: python manage.py build_translation_notifications
+
+  send-notifications:
+    needs: build-notifications
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    container:
+      image: ghcr.io/metro-records/la-metro-councilmatic:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Send notifications
+        run: python manage.py notify_translation_suite


### PR DESCRIPTION
## Overview

This pr adds a couple of workflows to notify the translation suite once a day about new documents. One workflow builds the notifications and then sends them. The other workflow sets it up to run once a day for both staging and prod.

Closes https://github.com/datamade/la-metro-translations/issues/3

### Notes
The prod job is commented out for now, but we can uncomment it when we start showing translations on this app!

If this workflow ever fails in the distant future, it'd be worth looking into whether the [database url for either environment has automatically changed on heroku](https://help.heroku.com/SMVK5PMS/why-have-my-heroku-postgres-credentials-changed).

We can also look into building a listener for that event so we can update it automatically on our side if/when that happens. We could use a [webhook on this app that listens for env var changes](https://devcenter.heroku.com/articles/app-webhooks) on prod/staging, and then connects to the [github api to change the secret](https://docs.github.com/en/rest/actions/secrets?apiVersion=2026-03-10#create-or-update-a-repository-secret) for each environment.

## Testing Instructions
 * Check [this run](https://github.com/Metro-Records/la-metro-councilmatic/actions/runs/25450165638) of the action and confirm it worked as expected
   * It currently says no notifications need to be sent because it sent 657 of them between both staging apps during local testing 🙌 
