### PR TITLE
Prevent TypeError when one set of notifs is empty

### DIFF
--- a/.github/workflows/daily_scheduler.yml
+++ b/.github/workflows/daily_scheduler.yml
@@ -1,6 +1,7 @@
 name: Daily translation notifications dispatcher
 
 on:
+  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "0 23 * * *" # Runs every day an hour before midnight UTC

--- a/.github/workflows/daily_scheduler.yml
+++ b/.github/workflows/daily_scheduler.yml
@@ -1,7 +1,6 @@
 name: Daily translation notifications dispatcher
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "0 23 * * *" # Runs every day an hour before midnight UTC

--- a/lametro/management/commands/build_translation_notifications.py
+++ b/lametro/management/commands/build_translation_notifications.py
@@ -100,8 +100,8 @@ class Command(BaseCommand):
             return
 
         logger.info(
-            f"Created notifications for {len(bill_notifications)} bills "
-            f"and {len(event_notifications)} events"
+            f"Created notifications for {len(bill_notifications or [])} bills "
+            f"and {len(event_notifications or [])} events."
         )
 
         # Clean up previously failed notifications for these entities


### PR DESCRIPTION
## Overview

When just one set of notifications (`bill_notifications` or `event_notifications`) is empty, notification objects don't get created, and it returns `None`.  This pr is a simple fix that provides a fallback value when we're checking how many notifications were made.

[Check out the original error in this failed run.](https://github.com/Metro-Records/la-metro-councilmatic/actions/runs/25584407056/job/75109999285#step:4:65)

## Testing Instructions
 * [Check out this successful run](https://github.com/Metro-Records/la-metro-councilmatic/actions/runs/25675542861/job/75373736291#step:4:54)
