### PR TITLE
Show recent meetings that did not have a live broadcast

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: black
 
   - repo: https://github.com/pycqa/flake8
-    rev: '9f60881'
+    rev: 'c48217e1'
     hooks:
       - id: flake8
         files: ^(lametro|councilmatic|tests)

--- a/lametro/models/legislative.py
+++ b/lametro/models/legislative.py
@@ -609,21 +609,18 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
     @classmethod
     def most_recent_past_meetings(cls):
         """
-        Returns meetings in the current month that have occured in the past
-        two weeks.
+        Returns meetings that have occured in the past two weeks.
 
         Don't check with has_passed cached property because some past
         meetings may not have had a live broadcast (see issue #1296)
         """
 
-        current_month = timezone.now().month
         two_weeks_ago = timezone.now() - timedelta(weeks=2)
         current_window_start = timezone.now() - timedelta(
             hours=cls.CURRENT_MEETING_WINDOW_IN_HOURS
         )
         meetings_in_past_two_weeks = (
             cls.objects.with_media()
-            .filter(start_time__month=current_month)
             .filter(start_time__gte=two_weeks_ago)
             .filter(start_time__lte=current_window_start)
             .order_by("-start_time")

--- a/lametro/models/legislative.py
+++ b/lametro/models/legislative.py
@@ -593,6 +593,14 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
 
     PASSED_ECOMMENT_MESSAGE = "Online public comment for this meeting has closed."
 
+    """
+    Fun fact: The longest Metro meeting on record is 5.38 hours
+    long (see issue #251). Hence, when looking for "current" meeting,
+    we check for meetings scheduled to begin up to six hours ago.
+    """
+
+    CURRENT_MEETING_WINDOW_IN_HOURS = 6
+
     objects = LAMetroEventManager()
 
     class Meta:
@@ -603,22 +611,26 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
         """
         Returns meetings in the current month that have occured in the past
         two weeks.
-        """
-        two_weeks_ago = timezone.now() - timedelta(weeks=2)
 
+        Don't check with has_passed cached property because some past
+        meetings may not have had a live broadcast (see issue #1296)
+        """
+
+        current_month = timezone.now().month
+        two_weeks_ago = timezone.now() - timedelta(weeks=2)
+        current_window_start = timezone.now() - timedelta(
+            hours=cls.CURRENT_MEETING_WINDOW_IN_HOURS
+        )
         meetings_in_past_two_weeks = (
             cls.objects.with_media()
+            .filter(start_time__month=current_month)
             .filter(start_time__gte=two_weeks_ago)
+            .filter(start_time__lte=current_window_start)
             .order_by("-start_time")
-            .prefetch_related("broadcast")
+            .exclude(status="cancelled")
         )
 
-        # since has_passed is a property of LAMetroEvent rather than
-        # a model attribute, we have to make sure returned meetings
-        # have concluded separately from the above Queryset filter
-        past_meetings = list(filter(lambda m: m.has_passed, meetings_in_past_two_weeks))
-
-        return past_meetings
+        return meetings_in_past_two_weeks
 
     @classmethod
     def upcoming_board_meetings(cls):
@@ -661,16 +673,9 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
     @classmethod
     def _potentially_current_meetings(cls):
         """
-        Return meetings that could be "current" – that is, meetings that are
-        scheduled to start in the last six hours, or in the next five minutes.
-
-        Fun fact: The longest Metro meeting on record is 5.38 hours long (see
-        issue #251). Hence, we check for meetings scheduled to begin up to six
-        hours ago.
-
         Used to determine whether to check Granicus for streaming meetings.
         """
-        six_hours_ago = cls._time_ago(hours=6)
+        current_window_start = cls._time_ago(hours=cls.CURRENT_MEETING_WINDOW_IN_HOURS)
         five_minutes_from_now = cls._time_from_now(minutes=5)
 
         was_cancelled = Q(status="cancelled")
@@ -682,7 +687,8 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
             cls.objects.including_test_events()
             .prefetch_related("broadcast")
             .filter(
-                start_time__gte=six_hours_ago, start_time__lte=five_minutes_from_now
+                start_time__gte=current_window_start,
+                start_time__lte=five_minutes_from_now,
             )
             .exclude(was_cancelled | has_passed)
         )

--- a/lametro/models/legislative.py
+++ b/lametro/models/legislative.py
@@ -616,13 +616,10 @@ class LAMetroEvent(Event, LiveMediaMixin, SourcesMixin):
         """
 
         two_weeks_ago = timezone.now() - timedelta(weeks=2)
-        current_window_start = timezone.now() - timedelta(
-            hours=cls.CURRENT_MEETING_WINDOW_IN_HOURS
-        )
         meetings_in_past_two_weeks = (
             cls.objects.with_media()
             .filter(start_time__gte=two_weeks_ago)
-            .filter(start_time__lte=current_window_start)
+            .filter(start_time__lte=timezone.now())
             .order_by("-start_time")
             .exclude(status="cancelled")
         )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -375,12 +375,7 @@ def test_most_recent_past_meetings(event):
     ten_days_ago = LAMetroEvent._time_ago(days=10).strftime("%Y-%m-%d %H:%M")
     five_days_ago = LAMetroEvent._time_ago(days=5).strftime("%Y-%m-%d %H:%M")
     four_days_ago = LAMetroEvent._time_ago(days=5).strftime("%Y-%m-%d %H:%M")
-    more_than_six_hours_ago_today = LAMetroEvent._time_ago(hours=7).strftime(
-        "%Y-%m-%d %H:%M"
-    )
-    potentially_current_today = LAMetroEvent._time_ago(minutes=120).strftime(
-        "%Y-%m-%d %H:%M"
-    )
+    earlier_today = LAMetroEvent._time_ago(hours=7).strftime("%Y-%m-%d %H:%M")
     one_hour_from_now = LAMetroEvent._time_from_now(minutes=60).strftime(
         "%Y-%m-%d %H:%M"
     )
@@ -390,11 +385,6 @@ def test_most_recent_past_meetings(event):
     event_older_than_two_weeks = event.build(
         name="Board Meeting",
         start_date=three_weeks_ago,
-        id=get_event_id(),
-    )
-    event_potentially_current_today = event.build(
-        name="Board Meeting",
-        start_date=potentially_current_today,
         id=get_event_id(),
     )
     event_later_today = event.build(
@@ -410,9 +400,9 @@ def test_most_recent_past_meetings(event):
         start_date=ten_days_ago,
         id=get_event_id(),
     )
-    event_more_than_six_hours_ago_today = event.build(
+    event_earlier_today = event.build(
         name="Board Meeting",
-        start_date=more_than_six_hours_ago_today,
+        start_date=earlier_today,
         id=get_event_id(),
     )
     event_five_days_ago = event.build(
@@ -432,14 +422,13 @@ def test_most_recent_past_meetings(event):
     assert len(recent_past_meetings) == 4
 
     assert event_older_than_two_weeks not in recent_past_meetings
-    assert event_potentially_current_today not in recent_past_meetings
     assert event_later_today not in recent_past_meetings
     assert event_one_week_from_now not in recent_past_meetings
 
     assert event_ten_days_ago in recent_past_meetings
     assert event_four_days_ago_no_broadcast in recent_past_meetings
     assert event_five_days_ago in recent_past_meetings
-    assert event_more_than_six_hours_ago_today in recent_past_meetings
+    assert event_earlier_today in recent_past_meetings
 
 
 @freeze_time("2021-02-07 12:00:00")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -369,22 +369,37 @@ def test_event_is_upcoming(event, mocker):
         assert not test_event.is_upcoming
 
 
-@freeze_time("2021-02-07 10:00:00")
+@freeze_time("2021-02-07 20:00:00")
 def test_most_recent_past_meetings(event):
     three_weeks_ago = LAMetroEvent._time_ago(days=21).strftime("%Y-%m-%d %H:%M")
-    five_days_ago = LAMetroEvent._time_ago(days=5).strftime("%Y-%m-%d %H:%M")
-    four_days_ago = LAMetroEvent._time_ago(days=4).strftime("%Y-%m-%d %H:%M")
-
-    earlier_today = LAMetroEvent._time_ago(minutes=120).strftime("%Y-%m-%d %H:%M")
+    ten_days_ago_last_month = LAMetroEvent._time_ago(days=10).strftime("%Y-%m-%d %H:%M")
+    five_days_ago_this_month = LAMetroEvent._time_ago(days=5).strftime("%Y-%m-%d %H:%M")
+    four_days_ago_this_month = LAMetroEvent._time_ago(days=5).strftime("%Y-%m-%d %H:%M")
+    more_than_six_hours_ago_today = LAMetroEvent._time_ago(hours=7).strftime(
+        "%Y-%m-%d %H:%M"
+    )
+    potentially_current_today = LAMetroEvent._time_ago(minutes=120).strftime(
+        "%Y-%m-%d %H:%M"
+    )
     one_hour_from_now = LAMetroEvent._time_from_now(minutes=60).strftime(
         "%Y-%m-%d %H:%M"
     )
     one_week_from_now = LAMetroEvent._time_from_now(days=7).strftime("%Y-%m-%d %H:%M")
 
-    # Events that shouldn't be returned
+    # Events that should NOT be returned
     event_older_than_two_weeks = event.build(
         name="Board Meeting",
         start_date=three_weeks_ago,
+        id=get_event_id(),
+    )
+    event_ten_days_ago_last_month = event.build(
+        name="Board Meeting",
+        start_date=ten_days_ago_last_month,
+        id=get_event_id(),
+    )
+    event_potentially_current_today = event.build(
+        name="Board Meeting",
+        start_date=potentially_current_today,
         id=get_event_id(),
     )
     event_later_today = event.build(
@@ -395,20 +410,21 @@ def test_most_recent_past_meetings(event):
     )
 
     # Events that should be returned
-    event_earlier_today = event.build(
+    event_more_than_six_hours_ago_today = event.build(
         name="Board Meeting",
-        start_date=earlier_today,
+        start_date=more_than_six_hours_ago_today,
         id=get_event_id(),
     )
-    event_four_days_ago = event.build(
+    event_five_days_ago_this_month = event.build(
         name="Board Meeting",
-        start_date=four_days_ago,
+        start_date=five_days_ago_this_month,
         id=get_event_id(),
     )
-    event_five_days_ago = event.build(
+    event_four_days_ago_this_month_no_broadcast = event.build(
         name="Board Meeting",
-        start_date=five_days_ago,
+        start_date=four_days_ago_this_month,
         id=get_event_id(),
+        has_broadcast=False,
     )
 
     recent_past_meetings = LAMetroEvent.most_recent_past_meetings()
@@ -416,12 +432,14 @@ def test_most_recent_past_meetings(event):
     assert len(recent_past_meetings) == 3
 
     assert event_older_than_two_weeks not in recent_past_meetings
+    assert event_ten_days_ago_last_month not in recent_past_meetings
+    assert event_potentially_current_today not in recent_past_meetings
     assert event_later_today not in recent_past_meetings
     assert event_one_week_from_now not in recent_past_meetings
 
-    assert event_four_days_ago in recent_past_meetings
-    assert event_five_days_ago in recent_past_meetings
-    assert event_earlier_today in recent_past_meetings
+    assert event_four_days_ago_this_month_no_broadcast in recent_past_meetings
+    assert event_five_days_ago_this_month in recent_past_meetings
+    assert event_more_than_six_hours_ago_today in recent_past_meetings
 
 
 @freeze_time("2021-02-07 12:00:00")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -372,9 +372,9 @@ def test_event_is_upcoming(event, mocker):
 @freeze_time("2021-02-07 20:00:00")
 def test_most_recent_past_meetings(event):
     three_weeks_ago = LAMetroEvent._time_ago(days=21).strftime("%Y-%m-%d %H:%M")
-    ten_days_ago_last_month = LAMetroEvent._time_ago(days=10).strftime("%Y-%m-%d %H:%M")
-    five_days_ago_this_month = LAMetroEvent._time_ago(days=5).strftime("%Y-%m-%d %H:%M")
-    four_days_ago_this_month = LAMetroEvent._time_ago(days=5).strftime("%Y-%m-%d %H:%M")
+    ten_days_ago = LAMetroEvent._time_ago(days=10).strftime("%Y-%m-%d %H:%M")
+    five_days_ago = LAMetroEvent._time_ago(days=5).strftime("%Y-%m-%d %H:%M")
+    four_days_ago = LAMetroEvent._time_ago(days=5).strftime("%Y-%m-%d %H:%M")
     more_than_six_hours_ago_today = LAMetroEvent._time_ago(hours=7).strftime(
         "%Y-%m-%d %H:%M"
     )
@@ -392,11 +392,6 @@ def test_most_recent_past_meetings(event):
         start_date=three_weeks_ago,
         id=get_event_id(),
     )
-    event_ten_days_ago_last_month = event.build(
-        name="Board Meeting",
-        start_date=ten_days_ago_last_month,
-        id=get_event_id(),
-    )
     event_potentially_current_today = event.build(
         name="Board Meeting",
         start_date=potentially_current_today,
@@ -410,35 +405,40 @@ def test_most_recent_past_meetings(event):
     )
 
     # Events that should be returned
+    event_ten_days_ago = event.build(
+        name="Board Meeting",
+        start_date=ten_days_ago,
+        id=get_event_id(),
+    )
     event_more_than_six_hours_ago_today = event.build(
         name="Board Meeting",
         start_date=more_than_six_hours_ago_today,
         id=get_event_id(),
     )
-    event_five_days_ago_this_month = event.build(
+    event_five_days_ago = event.build(
         name="Board Meeting",
-        start_date=five_days_ago_this_month,
+        start_date=five_days_ago,
         id=get_event_id(),
     )
-    event_four_days_ago_this_month_no_broadcast = event.build(
+    event_four_days_ago_no_broadcast = event.build(
         name="Board Meeting",
-        start_date=four_days_ago_this_month,
+        start_date=four_days_ago,
         id=get_event_id(),
         has_broadcast=False,
     )
 
     recent_past_meetings = LAMetroEvent.most_recent_past_meetings()
 
-    assert len(recent_past_meetings) == 3
+    assert len(recent_past_meetings) == 4
 
     assert event_older_than_two_weeks not in recent_past_meetings
-    assert event_ten_days_ago_last_month not in recent_past_meetings
     assert event_potentially_current_today not in recent_past_meetings
     assert event_later_today not in recent_past_meetings
     assert event_one_week_from_now not in recent_past_meetings
 
-    assert event_four_days_ago_this_month_no_broadcast in recent_past_meetings
-    assert event_five_days_ago_this_month in recent_past_meetings
+    assert event_ten_days_ago in recent_past_meetings
+    assert event_four_days_ago_no_broadcast in recent_past_meetings
+    assert event_five_days_ago in recent_past_meetings
     assert event_more_than_six_hours_ago_today in recent_past_meetings
 
 


### PR DESCRIPTION
## Overview

Look up recent meetings without checking broadcast status. 

Connects #1296 

### Notes

Initially discussed (with @derekeder) keeping the former `has_passed` method as a first pass and doing something else if that list was empty, but it could be the case that some meetings within the past 2 weeks had broadcasts and some didn't. Then our list would still be missing recent meetings that had no live broadcast, even though it wouldn't be showing the "No Recent Meetings" text. 

Assuming setting the `has_passed` cached property is still a fine way to mark meetings that have ended (versus checking for media, for example). Any place that relies on it will be wrong about events where broadcast media was added later, despite lack of live broadcast. Kept development scoped to Recent Meetings list only (barring creation of named constant due to reuse of magic number). 
