### PR TITLE
Use legislative session as fallback value for Fiscal Year in search

### DIFF
--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -104,7 +104,7 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         if obj.last_action_date:
             return obj.last_action_date
         if obj.bill_type in ("Board Correspondence", "Board Box"):
-            return obj.leg
+            return obj.created_at
         return None
 
     def prepare_topics(self, obj):

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -85,6 +85,13 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
             start_year=start_year, end_year=end_year
         )
 
+    def prepare_last_action_date(self, obj):
+        if obj.last_action_date:
+            return obj.last_action_date
+        if obj.bill_type in ("Board Correspondence", "Board Box"):
+            return obj.created_at
+        return None
+
     def prepare_topics(self, obj):
         return self._topics_from_classification(obj, "topics_exact")
 

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -74,19 +74,22 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         """
         aa = sorted(obj.actions_and_agendas, key=lambda i: i["date"], reverse=True)
         agendas = [a for a in aa if a["description"] == "SCHEDULED"]
+        start_year = None
+        end_year = None
+
         if len(aa) > 1:
             action_date = agendas[0]["date"] if agendas else aa[0]["date"]
-        elif obj.legislative_session and obj.legislative_session.start_date:
-            action_date = obj.legislative_session.start_date
+            if action_date.month <= 6:
+                start_year = action_date.year - 1
+                end_year = action_date.year
+            else:
+                start_year = action_date.year
+                end_year = action_date.year + 1
+        elif session := obj.legislative_session:
+            start_year = session.start_date.split("-")[0]
+            end_year = session.end_date.split("-")[0]
         else:
             return None
-
-        if action_date.month <= 6:
-            start_year = action_date.year - 1
-            end_year = action_date.year
-        else:
-            start_year = action_date.year
-            end_year = action_date.year + 1
 
         return "7/1/{start_year} to 6/30/{end_year}".format(
             start_year=start_year, end_year=end_year
@@ -101,7 +104,7 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         if obj.last_action_date:
             return obj.last_action_date
         if obj.bill_type in ("Board Correspondence", "Board Box"):
-            return obj.created_at
+            return obj.leg
         return None
 
     def prepare_topics(self, obj):

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -95,18 +95,6 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
             start_year=start_year, end_year=end_year
         )
 
-    def prepare_last_action_date(self, obj):
-        """
-        Use creation date to provide a last action date for board
-        correspondence, which otherwise don't usually have any
-        associated actions.
-        """
-        if obj.last_action_date:
-            return obj.last_action_date
-        if obj.bill_type in ("Board Correspondence", "Board Box"):
-            return obj.created_at
-        return None
-
     def prepare_topics(self, obj):
         return self._topics_from_classification(obj, "topics_exact")
 

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -68,23 +68,22 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         aa = sorted(obj.actions_and_agendas, key=lambda i: i["date"], reverse=True)
         agendas = [a for a in aa if a["description"] == "SCHEDULED"]
         if len(aa) > 1:
-            if agendas:
-                action_date = agendas[0]["date"]
-            else:
-                action_date = aa[0]["date"]
+            action_date = agendas[0]["date"] if agendas else aa[0]["date"]
+        elif obj.legislative_session and obj.legislative_session.start_date:
+            action_date = obj.legislative_session.start_date
+        else:
+            return None
 
-            if action_date.month <= 6:
-                start_year = action_date.year - 1
-                end_year = action_date.year
-            else:
-                start_year = action_date.year
-                end_year = action_date.year + 1
+        if action_date.month <= 6:
+            start_year = action_date.year - 1
+            end_year = action_date.year
+        else:
+            start_year = action_date.year
+            end_year = action_date.year + 1
 
-            session = "7/1/{start_year} to 6/30/{end_year}".format(
-                start_year=start_year, end_year=end_year
-            )
-            return session
-        return None
+        return "7/1/{start_year} to 6/30/{end_year}".format(
+            start_year=start_year, end_year=end_year
+        )
 
     def prepare_topics(self, obj):
         return self._topics_from_classification(obj, "topics_exact")

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -65,6 +65,13 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         )
 
     def prepare_legislative_session(self, obj):
+        """
+        Returns a fiscal year string for a given bill based on latest
+        action or agenda date.
+
+        If a bill doesn't have more than one of either, then use the
+        legislative session as fallback value.
+        """
         aa = sorted(obj.actions_and_agendas, key=lambda i: i["date"], reverse=True)
         agendas = [a for a in aa if a["description"] == "SCHEDULED"]
         if len(aa) > 1:
@@ -86,6 +93,11 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         )
 
     def prepare_last_action_date(self, obj):
+        """
+        Use creation date to provide a last action date for board
+        correspondence, which otherwise don't usually have any
+        associated actions.
+        """
         if obj.last_action_date:
             return obj.last_action_date
         if obj.bill_type in ("Board Correspondence", "Board Box"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,6 +113,8 @@ def legislative_session(db, jurisdiction):
         "identifier": "2017",
         "jurisdiction_id": "ocd-jurisdiction/country:us/state:ca/county:los_angeles/transit_authority",
         "name": "2017 Legislative Session",
+        "start_date": "2017-07-01",
+        "end_date": "2018-06-30",
     }
 
     session = LegislativeSession.objects.create(**session_info)

--- a/tests/test_solr_prep.py
+++ b/tests/test_solr_prep.py
@@ -97,6 +97,41 @@ def test_legislative_session(bill, metro_organization, event, mocker, month):
 
     assert indexed_data["legislative_session"] == expected_value
 
+
+def test_legislative_session_fallback(
+    bill, legislative_session, metro_organization, event, mocker
+):
+    bill = bill.build()
+    event = event.build()
+    org = metro_organization.build()
+    session = bill.legislative_session
+
+    now = datetime.now()
+
+    single_action = {
+        "date": datetime(now.year, 7, 1),
+        "description": "action descripton",
+        "event": event,
+        "organization": org,
+    }
+
+    mock_actions_and_agendas = mocker.PropertyMock(return_value=[single_action])
+
+    mocker.patch(
+        "lametro.models.LAMetroBill.actions_and_agendas",
+        new_callable=mock_actions_and_agendas,
+    )
+
+    index = LAMetroBillIndex()
+    indexed_data = index.prepare(bill)
+
+    expected_fmt = "7/1/{0} to 6/30/{1}"
+    expected_value = expected_fmt.format(
+        session.start_date.split("-")[0], session.end_date.split("-")[0]
+    )
+
+    assert indexed_data["legislative_session"] == expected_value
+
     # Test indexed value when there are neither actions nor agendas
     mock_actions_and_agendas = mocker.PropertyMock(return_value=[])
 
@@ -107,7 +142,7 @@ def test_legislative_session(bill, metro_organization, event, mocker, month):
 
     indexed_data = index.prepare(bill)
 
-    assert not indexed_data["legislative_session"]
+    assert indexed_data["legislative_session"] == expected_value
 
 
 def test_sponsorships(bill, metro_organization, event, event_related_entity, mocker):

--- a/tests/test_solr_prep.py
+++ b/tests/test_solr_prep.py
@@ -70,7 +70,7 @@ def test_legislative_session(bill, metro_organization, event, mocker, month):
 
     patch_aa(mocker, [recent_action, older_action, recent_agenda, older_agenda])
     indexed_data = index.prepare(bill)
-    expected_value = date_to_fy_string(recent_agenda.date)
+    expected_value = date_to_fy_string(recent_agenda["date"])
 
     assert indexed_data["legislative_session"] == expected_value
 
@@ -78,7 +78,7 @@ def test_legislative_session(bill, metro_organization, event, mocker, month):
 
     patch_aa(mocker, [recent_action, older_action])
     indexed_data = index.prepare(bill)
-    expected_value = date_to_fy_string(recent_action.date)
+    expected_value = date_to_fy_string(recent_action["date"])
 
     assert indexed_data["legislative_session"] == expected_value
 

--- a/tests/test_solr_prep.py
+++ b/tests/test_solr_prep.py
@@ -6,6 +6,15 @@ from opencivicdata.legislative.models import EventParticipant
 from lametro.search_indexes import LAMetroBillIndex
 
 
+# Helper function
+def patch_aa(mocker, return_value):
+    mocker.patch(
+        "lametro.models.LAMetroBill.actions_and_agendas",
+        new_callable=mocker.PropertyMock,
+        return_value=return_value,
+    )
+
+
 @pytest.mark.parametrize("month", [6, 7])
 def test_legislative_session(bill, metro_organization, event, mocker, month):
     """
@@ -16,11 +25,12 @@ def test_legislative_session(bill, metro_organization, event, mocker, month):
     which returns a dict of prepped data.
     https://github.com/django-haystack/django-haystack/blob/4910ccb01c31d12bf22dcb000894eece6c26f74b/haystack/indexes.py#L198
     """
+    # Set up
+    now = datetime.now()
     org = metro_organization.build()
     event = event.build()
     bill = bill.build()
-
-    now = datetime.now()
+    index = LAMetroBillIndex()
 
     # Create test actions and agendas
     recent_action = {
@@ -48,64 +58,37 @@ def test_legislative_session(bill, metro_organization, event, mocker, month):
         "organization": org,
     }
 
+    def date_to_fy_string(date):
+        """
+        Return the correct fiscal year for a given date, June (6) being the last month of the year.
+        """
+        start_year = date.year - 1 if date.month <= 6 else date.year
+        end_year = date.year if date.month <= 6 else date.year + 1
+        return "7/1/{0} to 6/30/{1}".format(start_year, end_year)
+
     # Test indexed value when there are both actions and agendas
-    mock_actions_and_agendas = mocker.PropertyMock(
-        return_value=[recent_action, older_action, recent_agenda, older_agenda]
-    )
 
-    mocker.patch(
-        "lametro.models.LAMetroBill.actions_and_agendas",
-        new_callable=mock_actions_and_agendas,
-    )
-
-    index = LAMetroBillIndex()
-    expected_fmt = "7/1/{0} to 6/30/{1}"
-
+    patch_aa(mocker, [recent_action, older_action, recent_agenda, older_agenda])
     indexed_data = index.prepare(bill)
-
-    if month <= 6:
-        expected_value = expected_fmt.format(
-            recent_agenda["date"].year - 1, recent_agenda["date"].year
-        )
-    else:
-        expected_value = expected_fmt.format(
-            recent_agenda["date"].year, recent_agenda["date"].year + 1
-        )
+    expected_value = date_to_fy_string(recent_agenda.date)
 
     assert indexed_data["legislative_session"] == expected_value
 
     # Test indexed value when there are just actions
-    mock_actions_and_agendas = mocker.PropertyMock(
-        return_value=[recent_action, older_action]
-    )
 
-    mocker.patch(
-        "lametro.models.LAMetroBill.actions_and_agendas",
-        new_callable=mock_actions_and_agendas,
-    )
-
+    patch_aa(mocker, [recent_action, older_action])
     indexed_data = index.prepare(bill)
-
-    if month <= 6:
-        expected_value = expected_fmt.format(
-            recent_action["date"].year - 1, recent_action["date"].year
-        )
-    else:
-        expected_value = expected_fmt.format(
-            recent_action["date"].year, recent_action["date"].year + 1
-        )
+    expected_value = date_to_fy_string(recent_action.date)
 
     assert indexed_data["legislative_session"] == expected_value
 
 
-def test_legislative_session_fallback(
-    bill, legislative_session, metro_organization, event, mocker
-):
+def test_legislative_session_fallback(bill, metro_organization, event, mocker):
     bill = bill.build()
     event = event.build()
     org = metro_organization.build()
     session = bill.legislative_session
-
+    index = LAMetroBillIndex()
     now = datetime.now()
 
     single_action = {
@@ -115,16 +98,9 @@ def test_legislative_session_fallback(
         "organization": org,
     }
 
-    mock_actions_and_agendas = mocker.PropertyMock(return_value=[single_action])
+    patch_aa(mocker, [single_action])
 
-    mocker.patch(
-        "lametro.models.LAMetroBill.actions_and_agendas",
-        new_callable=mock_actions_and_agendas,
-    )
-
-    index = LAMetroBillIndex()
     indexed_data = index.prepare(bill)
-
     expected_fmt = "7/1/{0} to 6/30/{1}"
     expected_value = expected_fmt.format(
         session.start_date.split("-")[0], session.end_date.split("-")[0]
@@ -133,13 +109,8 @@ def test_legislative_session_fallback(
     assert indexed_data["legislative_session"] == expected_value
 
     # Test indexed value when there are neither actions nor agendas
-    mock_actions_and_agendas = mocker.PropertyMock(return_value=[])
 
-    mocker.patch(
-        "lametro.models.LAMetroBill.actions_and_agendas",
-        new_callable=mock_actions_and_agendas,
-    )
-
+    patch_aa(mocker, [])
     indexed_data = index.prepare(bill)
 
     assert indexed_data["legislative_session"] == expected_value


### PR DESCRIPTION
## Overview 

This PR adds an alternate method for indexing fiscal year (prepare_legislative_session) for report types that do not have more than one associated action or agenda.

I'm not entirely clear on the business logic surrounding all board report types, but from my limited POV, it seems safe to include the legislative session start date of any bill as the fallback value for calculating the fiscal year. As written, any additional actions/agendas will still trigger an update on re-index as applicable. 
  
Otherwise existing logic is retained. 

Connects #1276 

### Testing

Locally, with search working, filter by Report Type "Board Correspondence". The Fiscal Year filter should still be there, and vice versa. The totals for each of these filters should correspond.