### PR TITLE
Use controlling body (MatterBodyName) instead of primary sponsor for search filters

### DIFF
--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -39,6 +39,9 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         orgs_list = [action["organization"].name for action in obj.actions_and_agendas]
         return set(orgs_list)
 
+    def prepare_controlling_body(self, obj):
+        return obj.controlling_body.name
+
     def prepare_actions(self, obj):
         return [str(action) for action in obj.actions.all()]
 

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -29,15 +29,11 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
     # Preloaded fields for display
     listing_description = indexes.CharField(indexed=False)
     last_action_description = indexes.CharField(indexed=False)
-    primary_sponsor = indexes.CharField(indexed=False)
     rich_topics = indexes.CharField(indexed=False)
     pseudo_topics = indexes.CharField(indexed=False)
 
     def get_model(self):
         return LAMetroBill
-
-    def prepare_controlling_body(self, obj):
-        return None
 
     def prepare_sponsorships(self, obj):
         orgs_list = [action["organization"].name for action in obj.actions_and_agendas]
@@ -132,10 +128,6 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
     def prepare_last_action_description(self, obj):
         if obj.current_action:
             return obj.current_action.description
-
-    def prepare_primary_sponsor(self, obj):
-        if obj.primary_sponsor:
-            return obj.primary_sponsor.name
 
     def prepare_rich_topics(self, obj):
         if rich_topics := list(obj.rich_topics.values("name", "classification")):

--- a/lametro/search_indexes.py
+++ b/lametro/search_indexes.py
@@ -40,7 +40,8 @@ class LAMetroBillIndex(BillIndex, indexes.Indexable):
         return set(orgs_list)
 
     def prepare_controlling_body(self, obj):
-        return obj.controlling_body.name
+        if obj.controlling_body:
+            return obj.controlling_body.name
 
     def prepare_actions(self, obj):
         return [str(action) for action in obj.actions.all()]

--- a/lametro/templates/search/_search_filter.html
+++ b/lametro/templates/search/_search_filter.html
@@ -1,7 +1,7 @@
 {% load extras %}
 {% load lametro_extras %}
 
-{% if facet_label != 'Controlling Body' and item_list|length > 0 %}
+{% if item_list|length > 0 %}
 
     <div class="accordion-item">
         <h3 class="accordion-header">
@@ -9,7 +9,7 @@
                 Filter by
                 {% if 'Legislation' in facet_label %}
                     Board Report Type
-                {% elif 'Sponsor' in facet_label %}
+                {% elif 'Controlling' in facet_label %}
                     Meeting
                 {% elif 'Legislative Session' in facet_label %}
                     Fiscal Year

--- a/lametro/templates/search/_tags.html
+++ b/lametro/templates/search/_tags.html
@@ -6,10 +6,10 @@
     {{ result.last_action_date|date:'n/d/Y' }} - {{ result.last_action_description | remove_action_subj }} (most recent action)
 </p>
 
-{% if result.primary_sponsor %}
+{% if result.controlling_body %}
     <p class="small text-muted mb-0">
         <i class="fa fa-fw fa-users" aria-hidden="true"></i>
-        {{ result.primary_sponsor }}
+        {{ result.controlling_body.0 }}
     </p>
 {% endif %}
 

--- a/lametro/templates/search/search.html
+++ b/lametro/templates/search/search.html
@@ -45,8 +45,8 @@
         <div class="accordion mb-4" id="report-details">
 
             <!-- Meetings -->
-            {% if facets.fields.sponsorships %}
-                {% with facet_name='sponsorships' facet_label='Meeting' item_list=facets.fields.sponsorships selected_list=selected_facets.sponsorships %}
+            {% if facets.fields.controlling_body %}
+                {% with facet_name='controlling_body' facet_label='Meeting' item_list=facets.fields.controlling_body selected_list=selected_facets.controlling_body %}
                     {% include 'search/_search_filter.html' %}
                 {% endwith %}
             {% endif %}

--- a/lametro/views.py
+++ b/lametro/views.py
@@ -653,7 +653,7 @@ class LAMetroCouncilmaticFacetedSearchView(CouncilmaticFacetedSearchView):
         sqs = (
             SearchQuerySet()
             .facet("bill_type")
-            .facet("sponsorships")
+            .facet("controlling_body")
             .facet("legislative_session")
             .facet("inferred_status")
             .facet("topics")


### PR DESCRIPTION
## Overview

In tandem with a [corresponding PR ](https://github.com/Metro-Records/scrapers-lametro/pull/62)in the scraper, we can now present the controlling body in the search results when filtering by Meetings.

Connects #1297

### Testing
Until the scraper you're using alongside your deployment of this PR, actually gets the above PR and starts populating `controlling_body` correctly, you will only get "Board of Directors" in the Meetings filter because the scraper is currently hard-coded to provide that for `controlling_body`

That also means of course that PR should be merged before we merge this one. I'm not sure what this means about updating existing database entries on prod.

### Notes

There was a line at the top of the search filter template like "if facet is not Controlling Body" that has been there since the [beginning of this file, 10 years ago.](https://github.com/Metro-Records/la-metro-councilmatic/blob/9f04ff1af43d992285496e686db8d212623beb65/lametro/templates/partials/search_filter.html)

So what this was guarding against, I do not know. I guess since `controlling_body` is defined in councilmatic-core Haystack indexing, we needed to override it and then skip it because we weren't using it / had hard-coded it to a placeholder value "Board of Directors"