### PR TITLE
Start sending translations notifs between prod environments

### DIFF
--- a/.github/workflows/daily_scheduler.yml
+++ b/.github/workflows/daily_scheduler.yml
@@ -1,6 +1,8 @@
 name: Daily translation notifications dispatcher
 
 on:
+  # TODO: remove pull_request after testing
+  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "0 23 * * *" # Runs every day an hour before midnight UTC

--- a/.github/workflows/daily_scheduler.yml
+++ b/.github/workflows/daily_scheduler.yml
@@ -1,8 +1,6 @@
 name: Daily translation notifications dispatcher
 
 on:
-  # TODO: remove pull_request after testing
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "0 23 * * *" # Runs every day an hour before midnight UTC

--- a/.github/workflows/daily_scheduler.yml
+++ b/.github/workflows/daily_scheduler.yml
@@ -12,8 +12,8 @@ jobs:
       environment: staging
     secrets: inherit
 
-  # production:
-  #   uses: ./.github/workflows/run_translation.yml
-  #   with:
-  #     environment: production
-  #   secrets: inherit
+  production:
+    uses: ./.github/workflows/notify_translations.yml
+    with:
+      environment: production
+    secrets: inherit


### PR DESCRIPTION
## Overview

Quick change to start sending notifications from to production. The environment variables to connect to councilmatic's prod db and translation's prod api have been set within the `production` environment on github.

Heroku's councilmatic prod environment is likewise set up to communicate with the translation suite and the translations prod s3 bucket.

This is the final part of the work done in #1299 

## Testing Instructions
 * Check out [this pr run](https://github.com/Metro-Records/la-metro-councilmatic/actions/runs/26898777205) and confirmed that it completed without issue.
