### PR TITLE
Don't affix labels to bills with no actions

### DIFF
--- a/lametro/templatetags/lametro_extras.py
+++ b/lametro/templatetags/lametro_extras.py
@@ -6,6 +6,7 @@ import urllib
 
 from django import template
 from django.utils import timezone
+from django.template.defaultfilters import stringfilter
 
 from councilmatic.settings_jurisdiction import (
     legislation_types,
@@ -346,7 +347,15 @@ def get_events_with_manual_broadcasts():
 def bill_status_from_last_action(description):
     if description and description.upper() in BILL_STATUS_DESCRIPTIONS.keys():
         return BILL_STATUS_DESCRIPTIONS[description.upper()]["search_term"]
-    return None
+    return ""
+
+
+@register.filter
+@stringfilter
+def inferred_status_label(status):
+    if not status:
+        return
+    return "<span class='label label-" + status.lower() + "'>" + status + "</span>"
 
 
 @register.inclusion_tag("snippets/fiscal_year_calendars.html", takes_context=True)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,18 @@
+from lametro.templatetags.lametro_extras import (
+    inferred_status_label,
+    bill_status_from_last_action,
+)
+
+
+def test_no_label_when_no_action():
+    status = bill_status_from_last_action(None)
+    html = inferred_status_label(status)
+
+    assert html is None
+
+
+def test_label_when_action():
+    status = bill_status_from_last_action("adopTEd as amenDed")
+    html = inferred_status_label(status)
+
+    assert html == "<span class='label label-adopted'>Adopted</span>"


### PR DESCRIPTION
## Overview

Hidden "None" statuses were appearing in event views. Now we return an empty string and overwrite the core `inferred_status_label` filter with a guard against empty strings.

Previously the councilmatic-core filter was marked `@stringfilter` and was thus coercing the `None` returned by the `bill_status_from_last_actio`n filter into `"None"` before running the rest of the filter.

Connects #1309